### PR TITLE
Use numpy api 1.7

### DIFF
--- a/extensions/helpers.cpp
+++ b/extensions/helpers.cpp
@@ -17,11 +17,20 @@
 *****************************************************************************/
 
 #include "helpers.hpp"
+#include <boost/python/stl_iterator.hpp>
+
 #include <iostream>
+#include <list>
+
+#include <ObjCryst/CrystVector/CrystVector.h>
+
+// Use numpy here, but initialize it later in the extension module.
+#include "pyobjcryst_numpy_setup.hpp"
+#define NO_IMPORT_ARRAY
+#include <numpy/arrayobject.h>
+
 
 namespace bp = boost::python;
-
-using namespace std;
 
 void swapstdout(std::ostream& buf)
 {
@@ -29,4 +38,35 @@ void swapstdout(std::ostream& buf)
     std::streambuf* cout_strbuf(std::cout.rdbuf());
     std::cout.rdbuf(buf.rdbuf());
     buf.rdbuf(cout_strbuf);
+}
+
+
+void assignCrystVector(CrystVector<double>& cv, bp::object obj)
+{
+    // copy data directly if it is a numpy array of doubles
+    PyArrayObject* a = PyArray_Check(obj.ptr()) ?
+        reinterpret_cast<PyArrayObject*>(obj.ptr()) : NULL;
+    bool isdoublenumpyarray = a &&
+        (1 == PyArray_NDIM(a)) &&
+        (NPY_DOUBLE == PyArray_TYPE(a));
+    if (isdoublenumpyarray)
+    {
+        const double* src = static_cast<double*>(PyArray_DATA(a));
+        npy_intp stride = PyArray_STRIDE(a, 0) / PyArray_ITEMSIZE(a);
+        cv.resize(PyArray_SIZE(a));
+        double* dst = cv.data();
+        const double* last = dst + cv.size();
+        for (; dst != last; ++dst, src += stride)  *dst = *src;
+    }
+    // otherwise copy elementwise converting each element to a double
+    else
+    {
+        bp::stl_input_iterator<double> begin(obj), end;
+        // use intermediate list to preserve cv when conversion fails.
+        std::list<double> values(begin, end);
+        cv.resize(values.size());
+        std::list<double>::const_iterator vv = values.begin();
+        double* dst = cv.data();
+        for (; vv != values.end(); ++vv, ++dst)  *dst = *vv;
+    }
 }

--- a/extensions/helpers.hpp
+++ b/extensions/helpers.hpp
@@ -109,4 +109,9 @@ bp::list setToPyList(std::set<T>& v)
 }
 
 
+// Extract CrystVector from a Python object
+template <class T> class CrystVector;
+
+void assignCrystVector(CrystVector<double>& cv, bp::object obj);
+
 #endif

--- a/extensions/powderpatternbackground_ext.cpp
+++ b/extensions/powderpatternbackground_ext.cpp
@@ -21,10 +21,9 @@
 #include <boost/python/args.hpp>
 #include <boost/python/copy_const_reference.hpp>
 
-#include <numpy/noprefix.h>
-#include <numpy/arrayobject.h>
-
 #include <ObjCryst/ObjCryst/PowderPattern.h>
+
+#include "helpers.hpp"
 
 namespace bp = boost::python;
 using namespace ObjCryst;
@@ -32,24 +31,12 @@ using namespace ObjCryst;
 namespace {
 
 void _SetInterpPoints(PowderPatternBackground& b,
-        PyObject* tth, PyObject* backgd)
+        bp::object tth, bp::object backgd)
 {
-    // FIXME -- adjust for NumPy C-API 1.7
-
-    // // cout << "_SetInterpPoints:" << tth << ", " << backgd << endl;
-    // // cout << "dimensions = " << PyArray_NDIM(tth) << endl;
-    // const unsigned long nb = *(PyArray_DIMS((PyObject*)tth));
-    // // cout << "nbPoints = " << nb << endl;
-    // CrystVector_REAL tth2(nb), backgd2(nb);
-    // // FIXME -- reuse some conversion function here
-    // //:TODO: We assume the arrays are contiguous & double (float64) !
-    // double* p = (double*) (PyArray_DATA(tth));
-    // double* p2 = (double*) (tth2.data());
-    // for (unsigned long i = 0; i < nb; i++) *p2++ = *p++;
-    // p = (double*) (PyArray_DATA(backgd));
-    // p2 = (double*) (backgd2.data());
-    // for (unsigned long i = 0; i < nb; i++) *p2++ = *p++;
-    // b.SetInterpPoints(tth2, backgd2);
+    CrystVector_REAL cvtth, cvbackg;
+    assignCrystVector(cvtth, tth);
+    assignCrystVector(cvbackg, backgd);
+    b.SetInterpPoints(cvtth, cvbackg);
 }
 
 }   // namespace

--- a/extensions/powderpatternbackground_ext.cpp
+++ b/extensions/powderpatternbackground_ext.cpp
@@ -27,7 +27,6 @@
 #include <ObjCryst/ObjCryst/PowderPattern.h>
 
 namespace bp = boost::python;
-using namespace boost::python;
 using namespace ObjCryst;
 
 namespace {
@@ -53,8 +52,10 @@ void _SetInterpPoints(PowderPatternBackground& b,
 
 }   // namespace
 
+
 void wrap_powderpatternbackground()
 {
+    using namespace boost::python;
     class_<PowderPatternBackground, bases<PowderPatternComponent>, boost::noncopyable>(
             "PowderPatternBackground", no_init)
         //.def("SetParentPowderPattern", &PowderPatternBackground::SetParentPowderPattern)

--- a/extensions/powderpatternbackground_ext.cpp
+++ b/extensions/powderpatternbackground_ext.cpp
@@ -34,20 +34,22 @@ namespace {
 void _SetInterpPoints(PowderPatternBackground& b,
         PyObject* tth, PyObject* backgd)
 {
-    // cout << "_SetInterpPoints:" << tth << ", " << backgd << endl;
-    // cout << "dimensions = " << PyArray_NDIM(tth) << endl;
-    const unsigned long nb = *(PyArray_DIMS((PyObject*)tth));
-    // cout << "nbPoints = " << nb << endl;
-    CrystVector_REAL tth2(nb), backgd2(nb);
-    // FIXME -- reuse some conversion function here
-    //:TODO: We assume the arrays are contiguous & double (float64) !
-    double* p = (double*) (PyArray_DATA(tth));
-    double* p2 = (double*) (tth2.data());
-    for (unsigned long i = 0; i < nb; i++) *p2++ = *p++;
-    p = (double*) (PyArray_DATA(backgd));
-    p2 = (double*) (backgd2.data());
-    for (unsigned long i = 0; i < nb; i++) *p2++ = *p++;
-    b.SetInterpPoints(tth2, backgd2);
+    // FIXME -- adjust for NumPy C-API 1.7
+
+    // // cout << "_SetInterpPoints:" << tth << ", " << backgd << endl;
+    // // cout << "dimensions = " << PyArray_NDIM(tth) << endl;
+    // const unsigned long nb = *(PyArray_DIMS((PyObject*)tth));
+    // // cout << "nbPoints = " << nb << endl;
+    // CrystVector_REAL tth2(nb), backgd2(nb);
+    // // FIXME -- reuse some conversion function here
+    // //:TODO: We assume the arrays are contiguous & double (float64) !
+    // double* p = (double*) (PyArray_DATA(tth));
+    // double* p2 = (double*) (tth2.data());
+    // for (unsigned long i = 0; i < nb; i++) *p2++ = *p++;
+    // p = (double*) (PyArray_DATA(backgd));
+    // p2 = (double*) (backgd2.data());
+    // for (unsigned long i = 0; i < nb; i++) *p2++ = *p++;
+    // b.SetInterpPoints(tth2, backgd2);
 }
 
 }   // namespace

--- a/extensions/pyobjcryst.cpp
+++ b/extensions/pyobjcryst.cpp
@@ -18,6 +18,11 @@
 
 #include <boost/python/module.hpp>
 
+// Initialize numpy here.
+#include "pyobjcryst_numpy_setup.hpp"
+#include <numpy/arrayobject.h>
+
+
 void wrap_asymmetricunit();
 void wrap_atom();
 void wrap_crystal();
@@ -63,6 +68,9 @@ void wrap_zscatterer();
 // Wrappers must be called according to inheritance hierarchy
 BOOST_PYTHON_MODULE(_pyobjcryst)
 {
+    // initialize numpy module
+    import_array();
+
     // General stuff
     wrap_general();
     wrap_io();

--- a/extensions/pyobjcryst_numpy_setup.hpp
+++ b/extensions/pyobjcryst_numpy_setup.hpp
@@ -1,0 +1,29 @@
+/*****************************************************************************
+*
+* pyobjcryst        Complex Modeling Initiative
+*                   (c) 2017 Brookhaven Science Associates
+*                   Brookhaven National Laboratory.
+*                   All rights reserved.
+*
+* File coded by:    Pavol Juhas
+*
+* See AUTHORS.txt for a list of people who contributed.
+* See LICENSE.txt for license information.
+*
+******************************************************************************
+*
+* Define PY_ARRAY_UNIQUE_SYMBOL for the pyobjcryst extension module.
+*
+*****************************************************************************/
+
+#ifndef PYOBJCRYST_NUMPY_SETUP_HPP_INCLUDED
+#define PYOBJCRYST_NUMPY_SETUP_HPP_INCLUDED
+
+// Specify the version of NumPy API that will be used.
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+// This macro is required for extension modules that are in several files.
+// It must be defined before inclusion of numpy/arrayobject.h
+#define PY_ARRAY_UNIQUE_SYMBOL PYOBJCRYST_NUMPY_ARRAY_SYMBOL
+
+#endif  // PYOBJCRYST_NUMPY_SETUP_HPP_INCLUDED

--- a/extensions/registerconverters.cpp
+++ b/extensions/registerconverters.cpp
@@ -23,14 +23,16 @@
 
 #include <vector>
 
-#include <numpy/noprefix.h>
-#include <numpy/arrayobject.h>
-
 #include <ObjCryst/CrystVector/CrystVector.h>
 #include <ObjCryst/ObjCryst/General.h>
 #include <ObjCryst/ObjCryst/Crystal.h>
 #include <ObjCryst/ObjCryst/ScatteringPower.h>
 #include <ObjCryst/ObjCryst/Molecule.h>
+
+// Use numpy here, but initialize it later in the extension module.
+#include "pyobjcryst_numpy_setup.hpp"
+#define NO_IMPORT_ARRAY
+#include <numpy/arrayobject.h>
 
 
 using namespace boost::python;
@@ -56,7 +58,7 @@ typedef std::vector<MolAtom*> MolAtomVec;
 PyObject* makeNdArray(double * data, std::vector<npy_intp>& dims)
 {
     PyObject* pyarray = PyArray_SimpleNewFromData
-                (dims.size(), &dims[0], PyArray_DOUBLE, (void *) data);
+                (dims.size(), &dims[0], NPY_DOUBLE, (void *) data);
     PyObject* pyarraycopy = PyArray_Copy( (PyArrayObject*) pyarray );
     return bp::incref(pyarraycopy);
 }
@@ -284,7 +286,6 @@ void wrap_registerconverters()
         object(handle<>(pyobjcryst_ObjCrystException));
 
     /* Data type converters */
-    import_array();
     to_python_converter< CrystVector<double>, CrystVector_REAL_to_ndarray >();
     to_python_converter< CrystMatrix<double>, CrystMatrix_REAL_to_ndarray >();
     // From boost sources


### PR DESCRIPTION
Avoid warnings on deprecated NumPy API such as at https://travis-ci.org/diffpy/pyobjcryst/jobs/223575548#L432

Declare NumPy API version 1.7 and adjust the numpy function calls accordingly.