### PR TITLE
ENH: avoid segfault when muted function throws

### DIFF
--- a/src/extensions/crystal_ext.cpp
+++ b/src/extensions/crystal_ext.cpp
@@ -182,10 +182,9 @@ _CreateCrystalFromCIF(bp::object input,
         const bool oneScatteringPowerPerElement=false,
         const bool connectAtoms=false)
 {
-    // Reading a cif file creates some output. Let's redirect stdout to a junk
-    // stream and then throw it away.
-    ostringstream junk;
-    swapstdout(junk);
+    // Reading a cif file creates some output via fpObjCrystInformUser.
+    // Mute the output and restore it on return or exception.
+    MuteObjCrystUserInfo muzzle;
 
     boost_adaptbx::python::streambuf sbuf(input);
     boost_adaptbx::python::streambuf::istream in(sbuf);
@@ -199,10 +198,6 @@ _CreateCrystalFromCIF(bp::object input,
             oneScatteringPowerPerElement, connectAtoms);
 
     int idx = gCrystalRegistry.GetNb();
-
-    // Switch the stream buffer back
-    swapstdout(junk);
-
     if(idx == idx0)
     {
         throw ObjCryst::ObjCrystException("Cannot create crystal from CIF");

--- a/src/extensions/crystal_ext.cpp
+++ b/src/extensions/crystal_ext.cpp
@@ -184,7 +184,9 @@ _CreateCrystalFromCIF(bp::object input,
 {
     // Reading a cif file creates some output via fpObjCrystInformUser.
     // Mute the output and restore it on return or exception.
+    // Also mute any hardcoded output to cout.
     MuteObjCrystUserInfo muzzle;
+    CaptureStdOut gag;
 
     boost_adaptbx::python::streambuf sbuf(input);
     boost_adaptbx::python::streambuf::istream in(sbuf);
@@ -196,6 +198,9 @@ _CreateCrystalFromCIF(bp::object input,
     const bool checkSymAsXYZ = true;
     ObjCryst::CreateCrystalFromCIF(cif, verbose, checkSymAsXYZ,
             oneScatteringPowerPerElement, connectAtoms);
+
+    gag.release();
+    muzzle.release();
 
     int idx = gCrystalRegistry.GetNb();
     if(idx == idx0)

--- a/src/extensions/helpers.cpp
+++ b/src/extensions/helpers.cpp
@@ -60,6 +60,33 @@ void MuteObjCrystUserInfo::release()
     msave_info_func = NULL;
 }
 
+// class CaptureStdOut -------------------------------------------------------
+
+CaptureStdOut::CaptureStdOut() :
+    msave_cout_buffer(std::cout.rdbuf())
+{
+    std::cout.rdbuf(moutput.rdbuf());
+}
+
+
+CaptureStdOut::~CaptureStdOut()
+{
+    this->release();
+}
+
+
+std::string CaptureStdOut::str() const
+{
+    return moutput.str();
+}
+
+
+void CaptureStdOut::release()
+{
+    if (msave_cout_buffer)  std::cout.rdbuf(msave_cout_buffer);
+    msave_cout_buffer = NULL;
+}
+
 // free functions ------------------------------------------------------------
 
 void swapstdout(std::ostream& buf)

--- a/src/extensions/helpers.cpp
+++ b/src/extensions/helpers.cpp
@@ -89,15 +89,6 @@ void CaptureStdOut::release()
 
 // free functions ------------------------------------------------------------
 
-void swapstdout(std::ostream& buf)
-{
-    // Switch the stream buffer with std::cout, which is used by Print.
-    std::streambuf* cout_strbuf(std::cout.rdbuf());
-    std::cout.rdbuf(buf.rdbuf());
-    buf.rdbuf(cout_strbuf);
-}
-
-
 void assignCrystVector(CrystVector<double>& cv, bp::object obj)
 {
     // copy data directly if it is a numpy array of doubles

--- a/src/extensions/helpers.hpp
+++ b/src/extensions/helpers.hpp
@@ -64,20 +64,12 @@ class CaptureStdOut
 
 };
 
-// Switch stdout with another stream. To get things back the right way, just
-// switch again with the same stream.
-void swapstdout(std::ostream& buf);
-
 template <class T>
 std::string __str__(const T& obj)
 {
-    // Switch the stream buffer with std::cout, which is used by Print.
-    std::ostringstream outbuf;
-    swapstdout(outbuf);
-    // Call Print()
+    CaptureStdOut outbuf;
     obj.Print();
-    // Switch the stream buffer back
-    swapstdout(outbuf);
+    outbuf.release();
 
     std::string outstr = outbuf.str();
     // Remove the trailing newline

--- a/src/extensions/helpers.hpp
+++ b/src/extensions/helpers.hpp
@@ -48,6 +48,21 @@ class MuteObjCrystUserInfo
         void (*msave_info_func)(const std::string &);
 };
 
+class CaptureStdOut
+{
+    public:
+
+        CaptureStdOut();
+        ~CaptureStdOut();
+        std::string str() const;
+        void release();
+
+    private:
+
+        std::ostringstream moutput;
+        std::streambuf* msave_cout_buffer;
+
+};
 
 // Switch stdout with another stream. To get things back the right way, just
 // switch again with the same stream.

--- a/src/extensions/powderpattern_ext.cpp
+++ b/src/extensions/powderpattern_ext.cpp
@@ -41,11 +41,9 @@ namespace {
 
 PowderPattern* _CreatePowderPatternFromCIF(bp::object input)
 {
-    // Reading a cif file creates some output. Let's redirect stdout to a junk
-    // stream and then throw it away.
-    // FIXME ... try to remove this kludge with junk buffer
-    ostringstream junk;
-    swapstdout(junk);
+    // Reading a cif file creates some output via fpObjCrystInformUser.
+    // Mute the output and restore it on return or exception.
+    MuteObjCrystUserInfo muzzle;
 
     boost_adaptbx::python::streambuf sbuf(input);
     boost_adaptbx::python::streambuf::istream in(sbuf);
@@ -56,10 +54,6 @@ PowderPattern* _CreatePowderPatternFromCIF(bp::object input)
     ObjCryst::CreatePowderPatternFromCIF(cif);
 
     int idx = gPowderPatternRegistry.GetNb();
-
-    // Switch the stream buffer back
-    swapstdout(junk);
-
     if(idx == idx0)
     {
         throw ObjCryst::ObjCrystException("Cannot create powder pattern from CIF");

--- a/src/extensions/powderpattern_ext.cpp
+++ b/src/extensions/powderpattern_ext.cpp
@@ -43,7 +43,9 @@ PowderPattern* _CreatePowderPatternFromCIF(bp::object input)
 {
     // Reading a cif file creates some output via fpObjCrystInformUser.
     // Mute the output and restore it on return or exception.
+    // Also mute any hardcoded output to cout.
     MuteObjCrystUserInfo muzzle;
+    CaptureStdOut gag;
 
     boost_adaptbx::python::streambuf sbuf(input);
     boost_adaptbx::python::streambuf::istream in(sbuf);
@@ -52,6 +54,9 @@ PowderPattern* _CreatePowderPatternFromCIF(bp::object input)
     int idx0 = gPowderPatternRegistry.GetNb();
 
     ObjCryst::CreatePowderPatternFromCIF(cif);
+
+    gag.release();
+    muzzle.release();
 
     int idx = gPowderPatternRegistry.GetNb();
     if(idx == idx0)


### PR DESCRIPTION
Use MuteObjCrystUserInfo to restore output on return or exception.
Avoid segfault in [diffpy-users example](https://groups.google.com/d/msg/diffpy-users/4d3iS19_16E/d9Rs17YuAwAJ) where stdout is left with invalid buffer after exception.

## TODO

- [x] add helper class CaptureStdOut to suppress leftover output