### PR TITLE
fix Molecule.GetAtom and FindAtom

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -119,6 +119,10 @@ env.PrependUnique(LIBPATH=getsyspaths('LIBRARY_PATH'))
 fast_linkflags = ['-s']
 fast_shlinkflags = pyconfigvar('LDSHARED').split()[1:]
 
+# Specify minimum C++ standard.  Allow later standard from sconscript.local.
+# In case of multiple `-std` options the last option holds.
+env.PrependUnique(CXXFLAGS='-std=c++11', delete_existing=1)
+
 # Platform specific intricacies.
 if env['PLATFORM'] == 'darwin':
     darwin_shlinkflags = [n for n in env['SHLINKFLAGS']

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ FALLBACK_VERSION = '2.1.0.post0'
 # define extension arguments here
 ext_kws = {
         'libraries' : ['ObjCryst'],
-        'extra_compile_args' : [],
+        'extra_compile_args' : ['-std=c++11'],
         'extra_link_args' : [],
         'include_dirs' : get_numpy_include_dirs(),
 }

--- a/src/extensions/helpers.cpp
+++ b/src/extensions/helpers.cpp
@@ -118,3 +118,16 @@ void assignCrystVector(CrystVector<double>& cv, bp::object obj)
         for (; vv != values.end(); ++vv, ++dst)  *dst = *vv;
     }
 }
+
+
+int check_index(int idx, int size, NegativeIndexFlag nflag)
+{
+    const int lo = (nflag == ALLOW_NEGATIVE) ? -size : 0;
+    if (idx < lo || idx >= size)
+    {
+        PyErr_SetString(PyExc_IndexError, "Index out of range.");
+        bp::throw_error_already_set();
+    }
+    int rv = (idx < 0) ? size + idx : idx;
+    return rv;
+}

--- a/src/extensions/helpers.hpp
+++ b/src/extensions/helpers.hpp
@@ -136,4 +136,8 @@ template <class T> class CrystVector;
 
 void assignCrystVector(CrystVector<double>& cv, bp::object obj);
 
+// check index bounds and convert negative index to equivalent value
+enum NegativeIndexFlag {POSITIVE, ALLOW_NEGATIVE};
+int check_index(int idx, int size, NegativeIndexFlag nflag);
+
 #endif

--- a/src/extensions/molecule_ext.cpp
+++ b/src/extensions/molecule_ext.cpp
@@ -152,14 +152,8 @@ size_t _GetNbRigidGroups(Molecule& m)
 // Overloaded for safety
 MolAtom& _GetAtomIdx(Molecule& m, int idx)
 {
-    std::vector<MolAtom*>& v = m.GetAtomList();
-    if(idx < 0) idx += v.size();
-    if(0 == v.size() || idx < 0 || idx >= (int) v.size())
-    {
-        PyErr_SetString(PyExc_IndexError, "Index out of range");
-        throw_error_already_set();
-    }
-    return *v[idx];
+    int i = check_index(idx, m.GetNbComponent(), ALLOW_NEGATIVE);
+    return m.GetAtom(i);
 }
 
 // Overloaded for safety

--- a/src/pyobjcryst/tests/testcrystal.py
+++ b/src/pyobjcryst/tests/testcrystal.py
@@ -104,11 +104,22 @@ class TestCrystal(unittest.TestCase):
         return
 
     def testGetScatterer(self):
-        """Test GetScatterer."""
+        """Test GetScatterer and GetScatt."""
         sp, atom = makeScatterer()
         c = makeCrystal(sp, atom)
-        for i in range(c.GetNbScatterer()):
-            c.GetScatterer(i)
+        for fget in (c.GetScatterer, c.GetScatt):
+            for i in range(c.GetNbScatterer()):
+                fget(i)
+            a = fget(0)
+            ani = fget("Ni")
+            self.assertEqual([a.X, a.Y, a.Z], [ani.X, ani.Y, ani.Z])
+            a.X = 0.112
+            self.assertEqual(a.X, ani.X)
+            aneg = fget(-1)
+            self.assertEqual(a.X, aneg.X)
+            self.assertRaises(ValueError, fget, 'invalid')
+            self.assertRaises(IndexError, fget, 10)
+            self.assertRaises(IndexError, fget, -2)
         return
 
     def testDummyAtom(self):

--- a/src/pyobjcryst/tests/testmolecule.py
+++ b/src/pyobjcryst/tests/testmolecule.py
@@ -127,6 +127,36 @@ class TestMolecule(unittest.TestCase):
 
         return
 
+
+    def testGetAtom(self):
+        "check Molecule.GetAtom."
+        m = self.m
+        a0 = m.GetAtom(0)
+        b0 = m.GetAtom("C0")
+        c0 = m.GetAtom(-60)
+        self.assertEqual([a0.X, a0.Y, a0.Z], [b0.X, b0.Y, b0.Z])
+        self.assertEqual([a0.X, a0.Y, a0.Z], [c0.X, c0.Y, c0.Z])
+        a0.X = 0.123
+        self.assertEqual(a0.X, b0.X)
+        self.assertEqual(a0.X, c0.X)
+        self.assertRaises(IndexError, m.GetAtom, 60)
+        self.assertRaises(IndexError, m.GetAtom, -61)
+        self.assertRaises(ValueError, m.GetAtom, "invalid")
+        return
+
+
+    def testFindAtom(self):
+        "check Molecule.FindAtom."
+        m = self.m
+        a0 = m.GetAtom(0)
+        b0 = m.FindAtom("C0")
+        self.assertEqual([a0.X, a0.Y, a0.Z], [b0.X, b0.Y, b0.Z])
+        a0.X = 0.123
+        self.assertEqual(a0.X, b0.X)
+        self.assertIs(None, m.FindAtom("invalid"))
+        return
+
+
     def testBonds(self):
         """Test the Bond methods."""
 


### PR DESCRIPTION
Avoid segfault crash when looking up invalid atom name.

CI tests only, for manual merge.