### PR TITLE
Fix spacegroup crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: generic
 
 os:
   - linux
-  - osx
+# - osx
 
 env:
-  - MYUSEMC=true MYPYTHON_VERSION=2.7
-  - MYUSEMC=true MYPYTHON_VERSION=3.5
-  - MYUSEMC=true MYPYTHON_VERSION=3.6
-  - MYUSEMC=true MYPYTHON_VERSION=3.7
+# - MYUSEMC=true MYPYTHON_VERSION=2.7
+# - MYUSEMC=true MYPYTHON_VERSION=3.5
+# - MYUSEMC=true MYPYTHON_VERSION=3.6
+# - MYUSEMC=true MYPYTHON_VERSION=3.7
   - MYUSEMC=false
 
 git:
@@ -83,7 +83,9 @@ before_install:
   - $NOSYS || devutils/makesdist
   - $NOSYS || MYTARBUNDLE="$(ls -t "${PWD}"/dist/*.tar.gz | head -1)"
   - $NOSYS || pushd ~/pkgs
-  - $NOSYS || git clone https://github.com/diffpy/libobjcryst.git
+  # FIXME - restore default clone after libobjcryst fix up
+  - $NOSYS || git clone -b pu-fix-spacegroup-recursion https://github.com/pavoljuhas/libobjcryst.git
+  # - $NOSYS || git clone https://github.com/diffpy/libobjcryst.git
   - $NOSYS || popd
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: generic
 
 os:
   - linux
-# - osx
+  - osx
 
 env:
-# - MYUSEMC=true MYPYTHON_VERSION=2.7
-# - MYUSEMC=true MYPYTHON_VERSION=3.5
-# - MYUSEMC=true MYPYTHON_VERSION=3.6
-# - MYUSEMC=true MYPYTHON_VERSION=3.7
+  - MYUSEMC=true MYPYTHON_VERSION=2.7
+  - MYUSEMC=true MYPYTHON_VERSION=3.5
+  - MYUSEMC=true MYPYTHON_VERSION=3.6
+  - MYUSEMC=true MYPYTHON_VERSION=3.7
   - MYUSEMC=false
 
 git:
@@ -83,9 +83,7 @@ before_install:
   - $NOSYS || devutils/makesdist
   - $NOSYS || MYTARBUNDLE="$(ls -t "${PWD}"/dist/*.tar.gz | head -1)"
   - $NOSYS || pushd ~/pkgs
-  # FIXME - restore default clone after libobjcryst fix up
-  - $NOSYS || git clone -b pu-fix-spacegroup-recursion https://github.com/pavoljuhas/libobjcryst.git
-  # - $NOSYS || git clone https://github.com/diffpy/libobjcryst.git
+  - $NOSYS || git clone https://github.com/diffpy/libobjcryst.git
   - $NOSYS || popd
 
 

--- a/src/extensions/general_ext.cpp
+++ b/src/extensions/general_ext.cpp
@@ -24,8 +24,8 @@
 #include <ObjCryst/version.h>
 #include <ObjCryst/ObjCryst/General.h>
 
-#if LIBOBJCRYST_VERSION < 2017002001000LL
-#error "pyobjcryst requires libobjcryst 2017.2.1 or later."
+#if LIBOBJCRYST_VERSION < 2017002002000LL
+#error "pyobjcryst requires libobjcryst 2017.2.2 or later."
 #endif
 
 using namespace boost::python;

--- a/src/extensions/spacegroup_ext.cpp
+++ b/src/extensions/spacegroup_ext.cpp
@@ -84,33 +84,18 @@ bp::list GetSymmetryOperations(const SpaceGroup& sg)
 
 SpaceGroup* CreateSpaceGroup(const std::string& sgid)
 {
-    SpaceGroup* rv = NULL;
-    try
-    {
-        MuteObjCrystUserInfo muzzle;
-        rv = new SpaceGroup(sgid);
-    }
-    catch (ObjCrystException e)
-    {
-        PyErr_SetString(PyExc_ValueError, e.message.c_str());
-        throw_error_already_set();
-    }
+    MuteObjCrystUserInfo muzzle;
+    // this may throw invalid_argument which is translated to ValueError
+    SpaceGroup* rv = new SpaceGroup(sgid);
     return rv;
 }
 
 
 void SafeChangeSpaceGroup(SpaceGroup& sg, const std::string& sgid)
 {
-    try
-    {
-        MuteObjCrystUserInfo muzzle;
-        sg.ChangeSpaceGroup(sgid);
-    }
-    catch (ObjCrystException e)
-    {
-        PyErr_SetString(PyExc_ValueError, e.message.c_str());
-        throw_error_already_set();
-    }
+    MuteObjCrystUserInfo muzzle;
+    // this may throw invalid_argument which is translated to ValueError
+    sg.ChangeSpaceGroup(sgid);
 }
 
 }   // namespace

--- a/src/extensions/spacegroup_ext.cpp
+++ b/src/extensions/spacegroup_ext.cpp
@@ -20,6 +20,7 @@
 #include <boost/python/args.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/tuple.hpp>
+#include <boost/python/make_constructor.hpp>
 
 #include <ObjCryst/ObjCryst/SpaceGroup.h>
 
@@ -80,7 +81,39 @@ bp::list GetSymmetryOperations(const SpaceGroup& sg)
     return outlist;
 }
 
+
+SpaceGroup* CreateSpaceGroup(const std::string& sgid)
+{
+    SpaceGroup* rv = NULL;
+    try
+    {
+        MuteObjCrystUserInfo muzzle;
+        rv = new SpaceGroup(sgid);
+    }
+    catch (ObjCrystException e)
+    {
+        PyErr_SetString(PyExc_ValueError, e.message.c_str());
+        throw_error_already_set();
+    }
+    return rv;
 }
+
+
+void SafeChangeSpaceGroup(SpaceGroup& sg, const std::string& sgid)
+{
+    try
+    {
+        MuteObjCrystUserInfo muzzle;
+        sg.ChangeSpaceGroup(sgid);
+    }
+    catch (ObjCrystException e)
+    {
+        PyErr_SetString(PyExc_ValueError, e.message.c_str());
+        throw_error_already_set();
+    }
+}
+
+}   // namespace
 
 
 void wrap_spacegroup()
@@ -88,9 +121,9 @@ void wrap_spacegroup()
 
     class_<SpaceGroup>("SpaceGroup")
         // Constructors
-        .def(init<const std::string&>((bp::arg("spgId"))))
+        .def("__init__", make_constructor(CreateSpaceGroup))
         // Methods
-        .def("ChangeSpaceGroup", &SpaceGroup::ChangeSpaceGroup)
+        .def("ChangeSpaceGroup", &SafeChangeSpaceGroup)
         .def("GetName", &SpaceGroup::GetName,
                 return_value_policy<copy_const_reference>())
         .def("IsInAsymmetricUnit", &SpaceGroup::IsInAsymmetricUnit)

--- a/src/pyobjcryst/tests/testpowderpattern.py
+++ b/src/pyobjcryst/tests/testpowderpattern.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python
+##############################################################################
+#
+# pyobjcryst        Complex Modeling Initiative
+#                   (c) 2018 Brookhaven Science Associates,
+#                   Brookhaven National Laboratory.
+#                   All rights reserved.
+#
+# File coded by:    Pavol Juhas
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
 
 """Unit tests for pyobjcryst.powderpattern
 """

--- a/src/pyobjcryst/tests/testspacegroup.py
+++ b/src/pyobjcryst/tests/testspacegroup.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# pyobjcryst        Complex Modeling Initiative
+#                   (c) 2019 Brookhaven Science Associates,
+#                   Brookhaven National Laboratory.
+#                   All rights reserved.
+#
+# File coded by:    Pavol Juhas
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
+
+"""Unit tests for pyobjcryst.spacegroup
+"""
+
+
+import unittest
+
+from pyobjcryst.spacegroup import SpaceGroup
+
+# ----------------------------------------------------------------------------
+
+class TestSpaceGroup(unittest.TestCase):
+
+    def setUp(self):
+        return
+
+
+    def test___init__(self):
+        "check SpaceGroup.__init__()"
+        sg = SpaceGroup()
+        self.assertEqual(1, sg.GetSpaceGroupNumber())
+        self.assertRaises(ValueError, SpaceGroup, "invalid")
+        sgfm3m = SpaceGroup("F m -3 m")
+        self.assertEqual(225, sgfm3m.GetSpaceGroupNumber())
+        sg3 = SpaceGroup("3")
+        self.assertEqual(3, sg3.GetSpaceGroupNumber())
+        return
+
+
+    def test_ChangeSpaceGroup(self):
+        "check SpaceGroup.ChangeSpaceGroup()"
+        sg = SpaceGroup("F m -3 m")
+        self.assertEqual("F m -3 m", sg.GetName())
+        self.assertRaises(ValueError, sg.ChangeSpaceGroup, "invalid")
+        self.assertEqual("F m -3 m", sg.GetName())
+        sg.ChangeSpaceGroup("P1")
+        self.assertEqual("P 1", sg.GetName())
+        return
+
+
+# End of class TestSpaceGroup
+
+# ----------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
fix hard crash on invalid space group name.
Thus far this requires topic libobjcryst branch

## TODO

- [x] release libObjCryst fix
- [x] restore full CI test
