### PR TITLE
Remove fallback version

### DIFF
--- a/news/fbv.rst
+++ b/news/fbv.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed fallback version handling in `src/pyobjcryst/version.py`.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/pyobjcryst/version.py
+++ b/src/pyobjcryst/version.py
@@ -18,13 +18,8 @@
 #  __all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
 
 # obtain version information
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
-FALLBACK_VERSION = "2024.2.1"
-
-try:
-    __version__ = version("pyobjcryst")
-except PackageNotFoundError:
-    __version__ = FALLBACK_VERSION
+__version__ = version("pyobjcryst")
 
 # End of file


### PR DESCRIPTION
@sbillinge please check, thanks

Removed fallback version handling in `src/pyobjcryst/version.py`.