### PR TITLE
docs: remove copied notebook files after building the documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,11 +38,25 @@ ab_authors = "Billinge Group members"
 # Include notebooks at build time.
 root_dir = Path(__file__).resolve().parents[1]
 external_nb_dir = root_dir / "examples"
+copied_files = []
 for f in external_nb_dir.glob("*.ipynb"):
     dest = Path(__file__).parent / "examples" / f.name
     if dest.exists():
         dest.unlink()
+    copied_files.append(dest)
     shutil.copy(f, dest)
+
+
+def post_build_hook(app, exception):
+    """Remove copied files after building documentation."""
+    for f in copied_files:
+        if f.exists():
+            f.unlink()
+
+
+def setup(app):
+    app.connect("build-finished", post_build_hook)
+
 
 # -- General configuration ------------------------------------------------
 

--- a/news/rm-copied-notebook.rst
+++ b/news/rm-copied-notebook.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Remove the copied notebooks after building the documentation.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address

Remove copied notebook files as mentioned in https://github.com/diffpy/pyobjcryst/issues/66#issuecomment-3155772083.

### What should the reviewer(s) do

Please check the modification.