### PR TITLE
docs: correctly create a link to QPA notebook file in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,7 +60,7 @@ Usage & notebooks
   * :doc:`Solving the cimetidine structure from its powder pattern <examples/structure-solution-powder-cimetidine>`
   * :doc:`Solving the PbSO4 structure from its X and N powder patterns <examples/structure-solution-powder-pbso4>`
   * :doc:`Meta-structure solution using multi-processing <examples/structure-solution-multiprocessing>`
-  * :doc:`Quantitative phase analysis (QPA) <examples/Quantitative-phase-analysis>`
+  * :doc:`Quantitative phase analysis (QPA) <examples/QPA-Quantitative phase analysis>`
 
 The **API documentation** can be found in :doc:`api/pyobjcryst`.
 

--- a/news/link-QPA.rst
+++ b/news/link-QPA.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Trivial change to index.rst
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
Previously, the main page does not correctly have a link to the QPA notebook. This PR fixes this issue by updating the link so that the link points to the correct notebook file. Results:
<img width="750" height="504" alt="image" src="https://github.com/user-attachments/assets/c0ea1fa5-481b-4ce2-bcae-d7189ff90ef4" />


### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
Please review and merge.