### PR TITLE
Add bindings to ReflectionProfile methods

### DIFF
--- a/.codespell/ignore_words.txt
+++ b/.codespell/ignore_words.txt
@@ -15,3 +15,6 @@ regist
 ;; src/pyobjcryst/crystal.py:548
 ;; alabelstyle parameter
 inFront
+
+;; tests/test_reflectionprofile.py: unittest assertions flagged as typos
+assertin

--- a/docs/source/api/pyobjcryst.rst
+++ b/docs/source/api/pyobjcryst.rst
@@ -117,6 +117,7 @@ pyobjcryst.powderpattern module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: ReflectionProfileType
 
 pyobjcryst.pyobjcryst_app module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,6 +139,14 @@ pyobjcryst.refineableobj module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pyobjcryst.refineableobj
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pyobjcryst.reflectionprofile module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: pyobjcryst.reflectionprofile
     :members:
     :undoc-members:
     :show-inheritance:

--- a/news/79.rst
+++ b/news/79.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Exposed `ReflectionProfile` methods (`GetProfile`, `GetFullProfileWidth`, `XMLOutput`, `XMLInput`) via Python bindings. Added unit tests.
+* The binding to `ReflectionProfile.GetProfile(x, xcenter, h, k, l)` accepts python sequences / `numpy` arrays for the `x` argument, thanks to the helper function `assignCrystVector`.
+
+**Changed:**
+
+* None.
+
+**Deprecated:**
+
+* None.
+
+**Removed:**
+
+* None.
+
+**Fixed:**
+
+* Building with `pip install .` now uses `sysconfig` to locate `ObjCryst++`` libraries outside conda environments.
+* Missing definition of `ScatteringData` in `powderpatterndiffraction_ext.ccp`
+
+**Security:**
+
+* None.

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,10 @@ def get_env_config():
     # no conda env: fallback to system/venv Python include/lib dirs
     py_inc = sysconfig.get_paths().get("include")
     libdir = sysconfig.get_config_var("LIBDIR") or "/usr/lib"
-    return {"include_dirs": [p for p in [py_inc] if p], "library_dirs": [libdir]}
+    return {
+        "include_dirs": [p for p in [py_inc] if p],
+        "library_dirs": [libdir],
+    }
 
 
 def create_extensions():

--- a/src/extensions/powderpatterndiffraction_ext.cpp
+++ b/src/extensions/powderpatterndiffraction_ext.cpp
@@ -1,21 +1,21 @@
 /*****************************************************************************
- *
- * pyobjcryst
- *
- * File coded by:    Vincent Favre-Nicolin
- *
- * See AUTHORS.txt for a list of people who contributed.
- * See LICENSE.txt for license information.
- *
- ******************************************************************************
- *
- * boost::python bindings to ObjCryst::PowderPatternDiffraction.
- *
- * Changes from ObjCryst::PowderPatternDiffraction
- *
- * Other Changes
- *
- *****************************************************************************/
+*
+* pyobjcryst
+*
+* File coded by:    Vincent Favre-Nicolin
+*
+* See AUTHORS.txt for a list of people who contributed.
+* See LICENSE.txt for license information.
+*
+******************************************************************************
+*
+* boost::python bindings to ObjCryst::PowderPatternDiffraction.
+*
+* Changes from ObjCryst::PowderPatternDiffraction
+*
+* Other Changes
+*
+*****************************************************************************/
 
 #include <boost/python/enum.hpp>
 #include <boost/python/class.hpp>
@@ -25,52 +25,56 @@
 
 #include <ObjCryst/ObjCryst/General.h>
 #include <ObjCryst/ObjCryst/PowderPattern.h>
-#include <ObjCryst/ObjCryst/ScatteringData.h>
+#include <ObjCryst/ObjCryst/ScatteringData.h> 
 
 namespace bp = boost::python;
 using namespace boost::python;
 using namespace ObjCryst;
 
+
 void wrap_powderpatterndiffraction()
 {
-        enum_<ReflectionProfileType>("ReflectionProfileType")
-            .value("PROFILE_GAUSSIAN", PROFILE_GAUSSIAN)
-            .value("PROFILE_LORENTZIAN", PROFILE_LORENTZIAN)
-            .value("PROFILE_PSEUDO_VOIGT", PROFILE_PSEUDO_VOIGT)
-            .value("PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT",
-                   PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT)
-            .value("PROFILE_PEARSON_VII", PROFILE_PEARSON_VII);
+    enum_<ReflectionProfileType>("ReflectionProfileType")
+        .value("PROFILE_GAUSSIAN", PROFILE_GAUSSIAN)
+        .value("PROFILE_LORENTZIAN", PROFILE_LORENTZIAN)
+        .value("PROFILE_PSEUDO_VOIGT", PROFILE_PSEUDO_VOIGT)
+        .value("PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT",
+                PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT)
+        .value("PROFILE_PEARSON_VII", PROFILE_PEARSON_VII)
+        ;
 
-        class_<PowderPatternDiffraction,
-               bases<PowderPatternComponent, ScatteringData>>(
-            "PowderPatternDiffraction", no_init)
-            .def("GetPowderPatternCalc",
-                 &PowderPatternDiffraction::GetPowderPatternCalc,
-                 return_value_policy<copy_const_reference>())
-            .def("SetReflectionProfilePar",
-                 &PowderPatternDiffraction::SetReflectionProfilePar,
-                 (bp::arg("type") = PROFILE_PSEUDO_VOIGT,
-                  bp::arg("fwhmCagliotiW") = 1e-6,
-                  bp::arg("fwhmCagliotiU") = 0,
-                  bp::arg("fwhmCagliotiV") = 0,
-                  bp::arg("eta0") = 0.5, bp::arg("eta1") = 0))
-            .def("GetProfile",
-                 (ReflectionProfile & (PowderPatternDiffraction::*)()) & PowderPatternDiffraction::GetProfile,
-                 return_internal_reference<>())
-            .def("SetExtractionMode",
-                 &PowderPatternDiffraction::SetExtractionMode,
-                 (bp::arg("extract") = true, bp::arg("init") = false))
-            .def("GetExtractionMode",
-                 &PowderPatternDiffraction::GetExtractionMode)
-            .def("ExtractLeBail",
-                 &PowderPatternDiffraction::ExtractLeBail,
-                 (bp::arg("nbcycle") = 1))
-            .def("SetCrystal",
-                 &PowderPatternDiffraction::SetCrystal,
-                 bp::arg("crystal"),
-                 with_custodian_and_ward<1, 2>())
-            .def("GetNbReflBelowMaxSinThetaOvLambda",
-                 &PowderPatternDiffraction::GetNbReflBelowMaxSinThetaOvLambda)
-            .def("GetFhklObsSq", &PowderPatternDiffraction::GetFhklObsSq,
-                 return_value_policy<copy_const_reference>());
+    class_<PowderPatternDiffraction,
+        bases<PowderPatternComponent, ScatteringData> >(
+                "PowderPatternDiffraction", no_init)
+        .def("GetPowderPatternCalc",
+                &PowderPatternDiffraction::GetPowderPatternCalc,
+                return_value_policy<copy_const_reference>())
+        .def("SetReflectionProfilePar",
+                &PowderPatternDiffraction::SetReflectionProfilePar,
+                (bp::arg("type")=PROFILE_PSEUDO_VOIGT,
+                 bp::arg("fwhmCagliotiW")=1e-6,
+                 bp::arg("fwhmCagliotiU")=0,
+                 bp::arg("fwhmCagliotiV")=0,
+                 bp::arg("eta0")=0.5, bp::arg("eta1")=0))
+        .def("GetProfile",
+                (ReflectionProfile& (PowderPatternDiffraction::*)())
+                &PowderPatternDiffraction::GetProfile,
+                return_internal_reference<>())
+        .def("SetExtractionMode",
+                &PowderPatternDiffraction::SetExtractionMode,
+                (bp::arg("extract")=true, bp::arg("init")=false))
+        .def("GetExtractionMode",
+                &PowderPatternDiffraction::GetExtractionMode)
+        .def("ExtractLeBail",
+                &PowderPatternDiffraction::ExtractLeBail,
+                (bp::arg("nbcycle")=1))
+        .def("SetCrystal",
+                &PowderPatternDiffraction::SetCrystal,
+                bp::arg("crystal"),
+                with_custodian_and_ward<1, 2>())
+        .def("GetNbReflBelowMaxSinThetaOvLambda",
+                &PowderPatternDiffraction::GetNbReflBelowMaxSinThetaOvLambda)
+        .def("GetFhklObsSq", &PowderPatternDiffraction::GetFhklObsSq,
+                return_value_policy<copy_const_reference>())
+        ;
 }

--- a/src/extensions/powderpatterndiffraction_ext.cpp
+++ b/src/extensions/powderpatterndiffraction_ext.cpp
@@ -1,21 +1,21 @@
 /*****************************************************************************
-*
-* pyobjcryst
-*
-* File coded by:    Vincent Favre-Nicolin
-*
-* See AUTHORS.txt for a list of people who contributed.
-* See LICENSE.txt for license information.
-*
-******************************************************************************
-*
-* boost::python bindings to ObjCryst::PowderPatternDiffraction.
-*
-* Changes from ObjCryst::PowderPatternDiffraction
-*
-* Other Changes
-*
-*****************************************************************************/
+ *
+ * pyobjcryst
+ *
+ * File coded by:    Vincent Favre-Nicolin
+ *
+ * See AUTHORS.txt for a list of people who contributed.
+ * See LICENSE.txt for license information.
+ *
+ ******************************************************************************
+ *
+ * boost::python bindings to ObjCryst::PowderPatternDiffraction.
+ *
+ * Changes from ObjCryst::PowderPatternDiffraction
+ *
+ * Other Changes
+ *
+ *****************************************************************************/
 
 #include <boost/python/enum.hpp>
 #include <boost/python/class.hpp>
@@ -25,56 +25,52 @@
 
 #include <ObjCryst/ObjCryst/General.h>
 #include <ObjCryst/ObjCryst/PowderPattern.h>
-#include <ObjCryst/ObjCryst/ScatteringData.h> 
+#include <ObjCryst/ObjCryst/ScatteringData.h>
 
 namespace bp = boost::python;
 using namespace boost::python;
 using namespace ObjCryst;
 
-
 void wrap_powderpatterndiffraction()
 {
-    enum_<ReflectionProfileType>("ReflectionProfileType")
-        .value("PROFILE_GAUSSIAN", PROFILE_GAUSSIAN)
-        .value("PROFILE_LORENTZIAN", PROFILE_LORENTZIAN)
-        .value("PROFILE_PSEUDO_VOIGT", PROFILE_PSEUDO_VOIGT)
-        .value("PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT",
-                PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT)
-        .value("PROFILE_PEARSON_VII", PROFILE_PEARSON_VII)
-        ;
+        enum_<ReflectionProfileType>("ReflectionProfileType")
+            .value("PROFILE_GAUSSIAN", PROFILE_GAUSSIAN)
+            .value("PROFILE_LORENTZIAN", PROFILE_LORENTZIAN)
+            .value("PROFILE_PSEUDO_VOIGT", PROFILE_PSEUDO_VOIGT)
+            .value("PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT",
+                   PROFILE_PSEUDO_VOIGT_FINGER_COX_JEPHCOAT)
+            .value("PROFILE_PEARSON_VII", PROFILE_PEARSON_VII);
 
-    class_<PowderPatternDiffraction,
-        bases<PowderPatternComponent, ScatteringData> >(
-                "PowderPatternDiffraction", no_init)
-        .def("GetPowderPatternCalc",
-                &PowderPatternDiffraction::GetPowderPatternCalc,
-                return_value_policy<copy_const_reference>())
-        .def("SetReflectionProfilePar",
-                &PowderPatternDiffraction::SetReflectionProfilePar,
-                (bp::arg("type")=PROFILE_PSEUDO_VOIGT,
-                 bp::arg("fwhmCagliotiW")=1e-6,
-                 bp::arg("fwhmCagliotiU")=0,
-                 bp::arg("fwhmCagliotiV")=0,
-                 bp::arg("eta0")=0.5, bp::arg("eta1")=0))
-        .def("GetProfile",
-                (ReflectionProfile& (PowderPatternDiffraction::*)())
-                &PowderPatternDiffraction::GetProfile,
-                return_internal_reference<>())
-        .def("SetExtractionMode",
-                &PowderPatternDiffraction::SetExtractionMode,
-                (bp::arg("extract")=true, bp::arg("init")=false))
-        .def("GetExtractionMode",
-                &PowderPatternDiffraction::GetExtractionMode)
-        .def("ExtractLeBail",
-                &PowderPatternDiffraction::ExtractLeBail,
-                (bp::arg("nbcycle")=1))
-        .def("SetCrystal",
-                &PowderPatternDiffraction::SetCrystal,
-                bp::arg("crystal"),
-                with_custodian_and_ward<1, 2>())
-        .def("GetNbReflBelowMaxSinThetaOvLambda",
-                &PowderPatternDiffraction::GetNbReflBelowMaxSinThetaOvLambda)
-        .def("GetFhklObsSq", &PowderPatternDiffraction::GetFhklObsSq,
-                return_value_policy<copy_const_reference>())
-        ;
+        class_<PowderPatternDiffraction,
+               bases<PowderPatternComponent, ScatteringData>>(
+            "PowderPatternDiffraction", no_init)
+            .def("GetPowderPatternCalc",
+                 &PowderPatternDiffraction::GetPowderPatternCalc,
+                 return_value_policy<copy_const_reference>())
+            .def("SetReflectionProfilePar",
+                 &PowderPatternDiffraction::SetReflectionProfilePar,
+                 (bp::arg("type") = PROFILE_PSEUDO_VOIGT,
+                  bp::arg("fwhmCagliotiW") = 1e-6,
+                  bp::arg("fwhmCagliotiU") = 0,
+                  bp::arg("fwhmCagliotiV") = 0,
+                  bp::arg("eta0") = 0.5, bp::arg("eta1") = 0))
+            .def("GetProfile",
+                 (ReflectionProfile & (PowderPatternDiffraction::*)()) & PowderPatternDiffraction::GetProfile,
+                 return_internal_reference<>())
+            .def("SetExtractionMode",
+                 &PowderPatternDiffraction::SetExtractionMode,
+                 (bp::arg("extract") = true, bp::arg("init") = false))
+            .def("GetExtractionMode",
+                 &PowderPatternDiffraction::GetExtractionMode)
+            .def("ExtractLeBail",
+                 &PowderPatternDiffraction::ExtractLeBail,
+                 (bp::arg("nbcycle") = 1))
+            .def("SetCrystal",
+                 &PowderPatternDiffraction::SetCrystal,
+                 bp::arg("crystal"),
+                 with_custodian_and_ward<1, 2>())
+            .def("GetNbReflBelowMaxSinThetaOvLambda",
+                 &PowderPatternDiffraction::GetNbReflBelowMaxSinThetaOvLambda)
+            .def("GetFhklObsSq", &PowderPatternDiffraction::GetFhklObsSq,
+                 return_value_policy<copy_const_reference>());
 }

--- a/src/extensions/powderpatterndiffraction_ext.cpp
+++ b/src/extensions/powderpatterndiffraction_ext.cpp
@@ -25,6 +25,7 @@
 
 #include <ObjCryst/ObjCryst/General.h>
 #include <ObjCryst/ObjCryst/PowderPattern.h>
+#include <ObjCryst/ObjCryst/ScatteringData.h> 
 
 namespace bp = boost::python;
 using namespace boost::python;

--- a/src/extensions/powderpatterndiffraction_ext.cpp
+++ b/src/extensions/powderpatterndiffraction_ext.cpp
@@ -25,7 +25,7 @@
 
 #include <ObjCryst/ObjCryst/General.h>
 #include <ObjCryst/ObjCryst/PowderPattern.h>
-#include <ObjCryst/ObjCryst/ScatteringData.h> 
+#include <ObjCryst/ObjCryst/ScatteringData.h>
 
 namespace bp = boost::python;
 using namespace boost::python;

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -1,21 +1,21 @@
 /*****************************************************************************
-*
-* pyobjcryst
-*
-* File coded by:    Vincent Favre-Nicolin
-*
-* See AUTHORS.txt for a list of people who contributed.
-* See LICENSE.txt for license information.
-*
-******************************************************************************
-*
-* boost::python bindings to ObjCryst::ReflectionProfile.
-*
-* Changes from ObjCryst::ReflectionProfile
-*
-* Other Changes
-*
-*****************************************************************************/
+ *
+ * pyobjcryst
+ *
+ * File coded by:    Vincent Favre-Nicolin
+ *
+ * See AUTHORS.txt for a list of people who contributed.
+ * See LICENSE.txt for license information.
+ *
+ ******************************************************************************
+ *
+ * boost::python bindings to ObjCryst::ReflectionProfile.
+ *
+ * Changes from ObjCryst::ReflectionProfile
+ *
+ * Other Changes
+ *
+ *****************************************************************************/
 
 #include <boost/python/class.hpp>
 #include <boost/python/manage_new_object.hpp>
@@ -30,23 +30,22 @@ namespace bp = boost::python;
 using namespace boost::python;
 using namespace ObjCryst;
 
-namespace {
-
-class ReflectionProfileWrap :
-    public ReflectionProfile, public wrapper<ReflectionProfile>
+namespace
 {
-    public:
 
+    class ReflectionProfileWrap : public ReflectionProfile, public wrapper<ReflectionProfile>
+    {
+    public:
         // Pure virtual functions
 
-        ReflectionProfile* CreateCopy() const
+        ReflectionProfile *CreateCopy() const
         {
             return this->get_override("CreateCopy")();
         }
 
         CrystVector_REAL GetProfile(
-                const CrystVector_REAL& x, const REAL xcenter,
-                const REAL h, const REAL k, const REAL l) const
+            const CrystVector_REAL &x, const REAL xcenter,
+            const REAL h, const REAL k, const REAL l) const
         {
             bp::override f = this->get_override("GetProfile");
             return f(x, xcenter, h, k, l);
@@ -60,29 +59,28 @@ class ReflectionProfileWrap :
             return f(relativeIntensity, xcenter, h, k, l);
         }
 
-        void XMLOutput(ostream& os, int indent) const
+        void XMLOutput(ostream &os, int indent) const
         {
             bp::override f = this->get_override("XMLOutput");
             f(os, indent);
         }
 
-        void XMLInput(istream& is, const XMLCrystTag& tag)
+        void XMLInput(istream &is, const XMLCrystTag &tag)
         {
             bp::override f = this->get_override("XMLInput");
             f(is, tag);
         }
-};
+    };
 
-}   // namespace
-
+} // namespace
 
 void wrap_reflectionprofile()
 {
     class_<ReflectionProfileWrap, bases<RefinableObj>, boost::noncopyable>(
-            "ReflectionProfile")
+        "ReflectionProfile")
         .def("CreateCopy",
-                pure_virtual(&ReflectionProfile::CreateCopy),
-                return_value_policy<manage_new_object>())
+             pure_virtual(&ReflectionProfile::CreateCopy),
+             return_value_policy<manage_new_object>())
         .def(
             "GetProfile",
             pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
@@ -93,9 +91,8 @@ void wrap_reflectionprofile()
              (bp::arg("relativeIntensity"), bp::arg("xcenter"),
               bp::arg("h"), bp::arg("k"), bp::arg("l")))
         .def("XMLOutput",
-            pure_virtual((void (ReflectionProfile::*)(ostream&, int) const)
-                         &ReflectionProfile::XMLOutput),
-            (bp::arg("os"), bp::arg("indent")))
+             pure_virtual((void (ReflectionProfile::*)(ostream &, int) const) & ReflectionProfile::XMLOutput),
+             (bp::arg("os"), bp::arg("indent")))
         .def("XMLInput",
              pure_virtual((void (ReflectionProfile::*)(istream &, const XMLCrystTag &))&ReflectionProfile::XMLInput),
              (bp::arg("is"), bp::arg("tag")));

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -22,6 +22,8 @@
 #include <boost/python/pure_virtual.hpp>
 #undef B0
 
+#include "helpers.hpp" // assignCrystVector helper for numpy/sequence inputs
+
 #include <iostream>
 
 #include <ObjCryst/ObjCryst/ReflectionProfile.h>
@@ -72,6 +74,16 @@ namespace
         }
     };
 
+    // Accept python sequences/ndarrays for x and forward to the C++ API.
+    CrystVector_REAL _GetProfile(
+        const ReflectionProfile &rp, bp::object x, const REAL xcenter,
+        const REAL h, const REAL k, const REAL l)
+    {
+        CrystVector_REAL cvx;
+        assignCrystVector(cvx, x);
+        return rp.GetProfile(cvx, xcenter, h, k, l);
+    }
+
 } // namespace
 
 void wrap_reflectionprofile()
@@ -83,9 +95,13 @@ void wrap_reflectionprofile()
              return_value_policy<manage_new_object>())
         .def(
             "GetProfile",
-            pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
+             pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
             (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"),
              bp::arg("k"), bp::arg("l")))
+        .def(
+            "GetProfile", &_GetProfile,
+            (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"), bp::arg("k"),
+             bp::arg("l")))
         .def("GetFullProfileWidth",
              pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL, const REAL) const) & ReflectionProfile::GetFullProfileWidth),
              (bp::arg("relativeIntensity"), bp::arg("xcenter"),

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -54,7 +54,7 @@ class ReflectionProfileWrap :
 
         REAL GetFullProfileWidth(
                 const REAL relativeIntensity, const REAL xcenter,
-                const REAL h, const REAL k, const REAL l)
+                const REAL h, const REAL k, const REAL l) const
         {
             bp::override f = this->get_override("GetFullProfileWidth");
             return f(relativeIntensity, xcenter, h, k, l);
@@ -68,7 +68,7 @@ class ReflectionProfileWrap :
 
         void XMLInput(istream& is, const XMLCrystTag& tag)
         {
-            bp::override f = this->get_override("GetProfile");
+            bp::override f = this->get_override("XMLInput");
             f(is, tag);
         }
 };
@@ -80,9 +80,27 @@ void wrap_reflectionprofile()
 {
     class_<ReflectionProfileWrap, bases<RefinableObj>, boost::noncopyable>(
             "ReflectionProfile")
-        // TODO add pure_virtual bindings to the remaining public methods
         .def("CreateCopy",
                 pure_virtual(&ReflectionProfile::CreateCopy),
                 return_value_policy<manage_new_object>())
+        .def(
+            "GetProfile",
+            pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL&, REAL, REAL, REAL) const)
+                         &ReflectionProfile::GetProfile),
+            (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"),
+             bp::arg("k"), bp::arg("l")))
+        .def("GetFullProfileWidth",
+            pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL) const)
+                         &ReflectionProfile::GetFullProfileWidth),
+            (bp::arg("relativeIntensity"), bp::arg("xcenter"),
+             bp::arg("h"), bp::arg("k"), bp::arg("l")))
+        .def("XMLOutput",
+            pure_virtual((void (ReflectionProfile::*)(ostream&, int) const)
+                         &ReflectionProfile::XMLOutput),
+            (bp::arg("os"), bp::arg("indent")))
+        .def("XMLInput",
+            pure_virtual((void (ReflectionProfile::*)(istream&, const XMLCrystTag&))
+                         &ReflectionProfile::XMLInput),
+            (bp::arg("is"), bp::arg("tag")))
         ;
 }

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -92,24 +92,33 @@ void wrap_reflectionprofile()
         "ReflectionProfile")
         .def("CreateCopy",
              pure_virtual(&ReflectionProfile::CreateCopy),
-             return_value_policy<manage_new_object>())
+             (return_value_policy<manage_new_object>()),
+             "Return a new ReflectionProfile instance copied from this one.")
+        // Two overloads for GetProfile:
+        // - Native CrystVector signature (for C++ callers / already-converted vectors).
+        // - Python-friendly wrapper that accepts sequences/ndarrays and converts them.
         .def(
             "GetProfile",
              pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
             (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"),
-             bp::arg("k"), bp::arg("l")))
+             bp::arg("k"), bp::arg("l")),
+             "Compute the profile values at positions `x` for reflection (h, k, l) centered at `xcenter`.")
         .def(
             "GetProfile", &_GetProfile,
             (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"), bp::arg("k"),
-             bp::arg("l")))
+             bp::arg("l")),
+             "Compute the profile values at positions `x` (sequence/ndarray accepted) for reflection (h, k, l) centered at `xcenter`.")
         .def("GetFullProfileWidth",
              pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL, const REAL) const) & ReflectionProfile::GetFullProfileWidth),
              (bp::arg("relativeIntensity"), bp::arg("xcenter"),
-              bp::arg("h"), bp::arg("k"), bp::arg("l")))
+              bp::arg("h"), bp::arg("k"), bp::arg("l")),
+              "Return the full profile width at a given relative intensity for reflection (h, k, l) around `xcenter`.")
         .def("XMLOutput",
              pure_virtual((void (ReflectionProfile::*)(ostream &, int) const) & ReflectionProfile::XMLOutput),
-             (bp::arg("os"), bp::arg("indent")))
+             (bp::arg("os"), bp::arg("indent")),
+             "Write this ReflectionProfile as XML to a file-like object. `indent` controls indentation depth.")
         .def("XMLInput",
              pure_virtual((void (ReflectionProfile::*)(istream &, const XMLCrystTag &))&ReflectionProfile::XMLInput),
-             (bp::arg("is"), bp::arg("tag")));
+             (bp::arg("is"), bp::arg("tag")),
+             "Load ReflectionProfile parameters from an XML stream and tag.");
 }

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -1,21 +1,21 @@
 /*****************************************************************************
-*
-* pyobjcryst
-*
-* File coded by:    Vincent Favre-Nicolin
-*
-* See AUTHORS.txt for a list of people who contributed.
-* See LICENSE.txt for license information.
-*
-******************************************************************************
-*
-* boost::python bindings to ObjCryst::ReflectionProfile.
-*
-* Changes from ObjCryst::ReflectionProfile
-*
-* Other Changes
-*
-*****************************************************************************/
+ *
+ * pyobjcryst
+ *
+ * File coded by:    Vincent Favre-Nicolin
+ *
+ * See AUTHORS.txt for a list of people who contributed.
+ * See LICENSE.txt for license information.
+ *
+ ******************************************************************************
+ *
+ * boost::python bindings to ObjCryst::ReflectionProfile.
+ *
+ * Changes from ObjCryst::ReflectionProfile
+ *
+ * Other Changes
+ *
+ *****************************************************************************/
 
 #include <boost/python/class.hpp>
 #include <boost/python/manage_new_object.hpp>
@@ -30,77 +30,70 @@ namespace bp = boost::python;
 using namespace boost::python;
 using namespace ObjCryst;
 
-namespace {
-
-class ReflectionProfileWrap :
-    public ReflectionProfile, public wrapper<ReflectionProfile>
+namespace
 {
-    public:
 
+    class ReflectionProfileWrap : public ReflectionProfile, public wrapper<ReflectionProfile>
+    {
+    public:
         // Pure virtual functions
 
-        ReflectionProfile* CreateCopy() const
+        ReflectionProfile *CreateCopy() const
         {
             return this->get_override("CreateCopy")();
         }
 
         CrystVector_REAL GetProfile(
-                const CrystVector_REAL& x, const REAL xcenter,
-                const REAL h, const REAL k, const REAL l) const
+            const CrystVector_REAL &x, const REAL xcenter,
+            const REAL h, const REAL k, const REAL l) const
         {
             bp::override f = this->get_override("GetProfile");
             return f(x, xcenter, h, k, l);
         }
 
         REAL GetFullProfileWidth(
-                const REAL relativeIntensity, const REAL xcenter,
-                const REAL h, const REAL k, const REAL l) const
+            const REAL relativeIntensity, const REAL xcenter,
+            const REAL h, const REAL k, const REAL l) const
         {
             bp::override f = this->get_override("GetFullProfileWidth");
             return f(relativeIntensity, xcenter, h, k, l);
         }
 
-        void XMLOutput(ostream& os, int indent) const
+        void XMLOutput(ostream &os, int indent) const
         {
             bp::override f = this->get_override("XMLOutput");
             f(os, indent);
         }
 
-        void XMLInput(istream& is, const XMLCrystTag& tag)
+        void XMLInput(istream &is, const XMLCrystTag &tag)
         {
             bp::override f = this->get_override("XMLInput");
             f(is, tag);
         }
-};
+    };
 
-}   // namespace
-
+} // namespace
 
 void wrap_reflectionprofile()
 {
     class_<ReflectionProfileWrap, bases<RefinableObj>, boost::noncopyable>(
-            "ReflectionProfile")
+        "ReflectionProfile")
         .def("CreateCopy",
-                pure_virtual(&ReflectionProfile::CreateCopy),
-                return_value_policy<manage_new_object>())
+             pure_virtual(&ReflectionProfile::CreateCopy),
+             return_value_policy<manage_new_object>())
         .def(
             "GetProfile",
-            pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL&, REAL, REAL, REAL) const)
-                         &ReflectionProfile::GetProfile),
+            pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
             (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"),
              bp::arg("k"), bp::arg("l")))
         .def("GetFullProfileWidth",
-            pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL) const)
-                         &ReflectionProfile::GetFullProfileWidth),
-            (bp::arg("relativeIntensity"), bp::arg("xcenter"),
-             bp::arg("h"), bp::arg("k"), bp::arg("l")))
+             pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL) const) & ReflectionProfile::GetFullProfileWidth),
+             (bp::arg("relativeIntensity"), bp::arg("xcenter"),
+              bp::arg("h"), bp::arg("k"), bp::arg("l")))
         .def("XMLOutput",
-            pure_virtual((void (ReflectionProfile::*)(ostream&, int) const)
-                         &ReflectionProfile::XMLOutput),
-            (bp::arg("os"), bp::arg("indent")))
+             pure_virtual((void (ReflectionProfile::*)(ostream &, int) const) & ReflectionProfile::XMLOutput),
+             (bp::arg("os"), bp::arg("indent")))
         .def("XMLInput",
-            pure_virtual((void (ReflectionProfile::*)(istream&, const XMLCrystTag&))
-                         &ReflectionProfile::XMLInput),
-            (bp::arg("is"), bp::arg("tag")))
-        ;
+             pure_virtual((void (ReflectionProfile::*)(istream &, const XMLCrystTag &))&ReflectionProfile::XMLInput),
+             (bp::arg("is"), bp::arg("tag")));
 }

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -54,7 +54,7 @@ class ReflectionProfileWrap :
 
         REAL GetFullProfileWidth(
             const REAL relativeIntensity, const REAL xcenter,
-            const REAL h, const REAL k, const REAL l) 
+            const REAL h, const REAL k, const REAL l)
         {
             bp::override f = this->get_override("GetFullProfileWidth");
             return f(relativeIntensity, xcenter, h, k, l);

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -53,7 +53,7 @@ namespace
 
         REAL GetFullProfileWidth(
             const REAL relativeIntensity, const REAL xcenter,
-            const REAL h, const REAL k, const REAL l) const
+            const REAL h, const REAL k, const REAL l) 
         {
             bp::override f = this->get_override("GetFullProfileWidth");
             return f(relativeIntensity, xcenter, h, k, l);
@@ -83,11 +83,11 @@ void wrap_reflectionprofile()
              return_value_policy<manage_new_object>())
         .def(
             "GetProfile",
-            pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
+            pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
             (bp::arg("x"), bp::arg("xcenter"), bp::arg("h"),
              bp::arg("k"), bp::arg("l")))
         .def("GetFullProfileWidth",
-             pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL) const) & ReflectionProfile::GetFullProfileWidth),
+             pure_virtual((REAL (ReflectionProfile::*)(const REAL, const REAL, const REAL, const REAL, const REAL) const) & ReflectionProfile::GetFullProfileWidth),
              (bp::arg("relativeIntensity"), bp::arg("xcenter"),
               bp::arg("h"), bp::arg("k"), bp::arg("l")))
         .def("XMLOutput",

--- a/src/extensions/reflectionprofile_ext.cpp
+++ b/src/extensions/reflectionprofile_ext.cpp
@@ -1,21 +1,21 @@
 /*****************************************************************************
- *
- * pyobjcryst
- *
- * File coded by:    Vincent Favre-Nicolin
- *
- * See AUTHORS.txt for a list of people who contributed.
- * See LICENSE.txt for license information.
- *
- ******************************************************************************
- *
- * boost::python bindings to ObjCryst::ReflectionProfile.
- *
- * Changes from ObjCryst::ReflectionProfile
- *
- * Other Changes
- *
- *****************************************************************************/
+*
+* pyobjcryst
+*
+* File coded by:    Vincent Favre-Nicolin
+*
+* See AUTHORS.txt for a list of people who contributed.
+* See LICENSE.txt for license information.
+*
+******************************************************************************
+*
+* boost::python bindings to ObjCryst::ReflectionProfile.
+*
+* Changes from ObjCryst::ReflectionProfile
+*
+* Other Changes
+*
+*****************************************************************************/
 
 #include <boost/python/class.hpp>
 #include <boost/python/manage_new_object.hpp>
@@ -30,22 +30,23 @@ namespace bp = boost::python;
 using namespace boost::python;
 using namespace ObjCryst;
 
-namespace
-{
+namespace {
 
-    class ReflectionProfileWrap : public ReflectionProfile, public wrapper<ReflectionProfile>
-    {
+class ReflectionProfileWrap :
+    public ReflectionProfile, public wrapper<ReflectionProfile>
+{
     public:
+
         // Pure virtual functions
 
-        ReflectionProfile *CreateCopy() const
+        ReflectionProfile* CreateCopy() const
         {
             return this->get_override("CreateCopy")();
         }
 
         CrystVector_REAL GetProfile(
-            const CrystVector_REAL &x, const REAL xcenter,
-            const REAL h, const REAL k, const REAL l) const
+                const CrystVector_REAL& x, const REAL xcenter,
+                const REAL h, const REAL k, const REAL l) const
         {
             bp::override f = this->get_override("GetProfile");
             return f(x, xcenter, h, k, l);
@@ -59,28 +60,29 @@ namespace
             return f(relativeIntensity, xcenter, h, k, l);
         }
 
-        void XMLOutput(ostream &os, int indent) const
+        void XMLOutput(ostream& os, int indent) const
         {
             bp::override f = this->get_override("XMLOutput");
             f(os, indent);
         }
 
-        void XMLInput(istream &is, const XMLCrystTag &tag)
+        void XMLInput(istream& is, const XMLCrystTag& tag)
         {
             bp::override f = this->get_override("XMLInput");
             f(is, tag);
         }
-    };
+};
 
-} // namespace
+}   // namespace
+
 
 void wrap_reflectionprofile()
 {
     class_<ReflectionProfileWrap, bases<RefinableObj>, boost::noncopyable>(
-        "ReflectionProfile")
+            "ReflectionProfile")
         .def("CreateCopy",
-             pure_virtual(&ReflectionProfile::CreateCopy),
-             return_value_policy<manage_new_object>())
+                pure_virtual(&ReflectionProfile::CreateCopy),
+                return_value_policy<manage_new_object>())
         .def(
             "GetProfile",
             pure_virtual((CrystVector_REAL (ReflectionProfile::*)(const CrystVector_REAL &, REAL, REAL, REAL, REAL) const) & ReflectionProfile::GetProfile),
@@ -91,8 +93,9 @@ void wrap_reflectionprofile()
              (bp::arg("relativeIntensity"), bp::arg("xcenter"),
               bp::arg("h"), bp::arg("k"), bp::arg("l")))
         .def("XMLOutput",
-             pure_virtual((void (ReflectionProfile::*)(ostream &, int) const) & ReflectionProfile::XMLOutput),
-             (bp::arg("os"), bp::arg("indent")))
+            pure_virtual((void (ReflectionProfile::*)(ostream&, int) const)
+                         &ReflectionProfile::XMLOutput),
+            (bp::arg("os"), bp::arg("indent")))
         .def("XMLInput",
              pure_virtual((void (ReflectionProfile::*)(istream &, const XMLCrystTag &))&ReflectionProfile::XMLInput),
              (bp::arg("is"), bp::arg("tag")));

--- a/src/pyobjcryst/reflectionprofile.py
+++ b/src/pyobjcryst/reflectionprofile.py
@@ -9,12 +9,43 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-"""Python wrapping of PowderPattern.h.
+"""Python wrapping of ReflectionProfile.h.
 
 See the online ObjCryst++ documentation (https://objcryst.readthedocs.io).
 
-Changes from ObjCryst::ReflectionProfile::
-        In development !
+A ``ReflectionProfile`` describes the shape of a single Bragg
+reflection (pseudo-Voigt by default) and is owned by a
+``PowderPatternDiffraction``. The Python bindings expose the
+public methods ``GetProfile``, ``GetFullProfileWidth``,
+``XMLOutput`` / ``XMLInput`` and ``CreateCopy``. ``GetProfile``
+accepts a Python sequence or numpy array for ``x``.
+
+Example
+-------
+
+Sample the profile of a single ``(h, k, l)`` reflection from an
+existing ``PowderPatternDiffraction`` and broaden it by tweaking
+the ``W`` Caglioti parameter::
+
+    import numpy as np
+    from pyobjcryst.powderpattern import PowderPattern
+
+    pp = PowderPattern()
+    pp.SetWavelength(0.7)
+    x = np.deg2rad(np.linspace(0, 40, 1000))
+    pp.SetPowderPatternX(x)
+    pp.SetPowderPatternObs(np.ones_like(x))
+    ppd = pp.AddPowderPatternDiffraction(crystal)   # crystal: pyobjcryst.Crystal
+
+    profile = ppd.GetProfile()
+    window = x[100:200]
+    xcenter = float(window[len(window) // 2])
+
+    y = profile.GetProfile(window, xcenter, 1, 0, 0)
+    fwhm = profile.GetFullProfileWidth(0.5, xcenter, 1, 0, 0)
+
+    profile.GetPar("W").SetValue(0.05)
+    y_broader = profile.GetProfile(window, xcenter, 1, 0, 0)
 """
 
 __all__ = ["ReflectionProfile", "ReflectionProfileType"]

--- a/tests/test_reflectionprofile.py
+++ b/tests/test_reflectionprofile.py
@@ -1,5 +1,4 @@
-"""
-Unit tests for pyobjcryst.reflectionprofile bindings.
+"""Unit tests for pyobjcryst.reflectionprofile bindings.
 
 TODO:
 - ReflectionProfile.GetProfile
@@ -9,14 +8,15 @@ TODO:
 """
 
 import unittest
-import pytest
+
 import numpy as np
+import pytest
 
 from pyobjcryst.powderpattern import PowderPattern
 
 
 class TestReflectionProfile(unittest.TestCase):
-    """Tests for ReflectionProfile methods"""
+    """Tests for ReflectionProfile methods."""
 
     @pytest.fixture(autouse=True)
     def prepare_fixture(self, loadcifdata):

--- a/tests/test_reflectionprofile.py
+++ b/tests/test_reflectionprofile.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for pyobjcryst.reflectionprofile bindings.
+
+TODO:
+- ReflectionProfile.GetProfile
+- ReflectionProfile.GetFullProfileWidth
+- ReflectionProfile.XMLOutput / XMLInput
+- ReflectionProfile.CreateCopy
+"""
+
+import unittest
+import pytest
+import numpy as np
+
+from pyobjcryst.powderpattern import PowderPattern
+
+
+class TestReflectionProfile(unittest.TestCase):
+    """Tests for ReflectionProfile methods"""
+
+    @pytest.fixture(autouse=True)
+    def prepare_fixture(self, loadcifdata):
+        self.loadcifdata = loadcifdata
+
+    def setUp(self):
+        """Set up a ReflectionProfile instance for testing."""
+        x = np.linspace(0, 40, 8001)
+        c = self.loadcifdata("paracetamol.cif")
+
+        self.pp = PowderPattern()
+        self.pp.SetWavelength(0.7)
+        self.pp.SetPowderPatternX(np.deg2rad(x))
+        self.pp.SetPowderPatternObs(np.ones_like(x))
+
+        self.ppd = self.pp.AddPowderPatternDiffraction(c)
+
+        self.profile = self.ppd.GetProfile()
+
+    def test_get_computed_profile(self):
+        assert True
+
+    def test_get_profile_width(self):
+        assert True
+
+    def test_create_copy(self):
+        assert True
+
+    def test_xml_input(self):
+        assert True
+
+    def test_xml_output(self):
+        assert True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reflectionprofile.py
+++ b/tests/test_reflectionprofile.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from pyobjcryst.powderpattern import PowderPattern
+from pyobjcryst.refinableobj import RefinableObj
 
 
 class TestReflectionProfile(unittest.TestCase):
@@ -24,7 +25,7 @@ class TestReflectionProfile(unittest.TestCase):
 
     def setUp(self):
         """Set up a ReflectionProfile instance for testing."""
-        x = np.linspace(0, 40, 8001)
+        x = np.linspace(0, 40, 1000)
         c = self.loadcifdata("paracetamol.cif")
 
         self.pp = PowderPattern()
@@ -37,19 +38,76 @@ class TestReflectionProfile(unittest.TestCase):
         self.profile = self.ppd.GetProfile()
 
     def test_get_computed_profile(self):
-        assert True
+        """Sample a profile slice and verify broadening lowers the peak height."""
+        x = self.pp.GetPowderPatternX()
+        hkl = (1, 0, 0)
+        window = x[100:200]
+        xcenter = float(window[len(window) // 2])
+
+        prof_default = self.profile.GetProfile(window, xcenter, *hkl)
+        self.assertEqual(len(prof_default), len(window))
+        self.assertGreater(prof_default.max(), 0)
+
+        # broaden and ensure the peak height drops while shape changes
+        self.profile.GetPar("W").SetValue(0.05)
+        prof_broader = self.profile.GetProfile(window, xcenter, *hkl)
+
+        self.assertFalse(np.allclose(prof_default, prof_broader))
+        self.assertLess(prof_broader.max(), prof_default.max())
+        self.assertEqual(len(prof_default), len(prof_broader))
 
     def test_get_profile_width(self):
-        assert True
+        """Ensure full-width increases when W increases."""
+        xcenter = float(self.pp.GetPowderPatternX()[len(self.pp.GetPowderPatternX()) // 4])
+        width_default = self.profile.GetFullProfileWidth(0.5, xcenter, 1, 0, 0)
+        self.assertGreater(width_default, 0)
+
+        self.profile.GetPar("W").SetValue(0.05)
+        width_broader = self.profile.GetFullProfileWidth(0.5, xcenter, 1, 0, 0)
+        self.assertGreater(width_broader, width_default)
 
     def test_create_copy(self):
-        assert True
+        """Ensure copy returns an independent profile with identical initial params."""
+        copy = self.profile.CreateCopy()
+
+        self.assertIsNot(copy, self.profile)
+        self.assertEqual(copy.GetClassName(), self.profile.GetClassName())
+
+        eta0_original = self.profile.GetPar("Eta0").GetValue()
+        eta0_copy = copy.GetPar("Eta0").GetValue()
+        self.assertAlmostEqual(eta0_copy, eta0_original)
+
+        self.profile.GetPar("Eta0").SetValue(eta0_original + 0.1)
+        copy.GetPar("Eta0").SetValue(eta0_copy + 0.2)
+
+        self.assertAlmostEqual(copy.GetPar("Eta0").GetValue(), eta0_original + 0.2)
+        self.assertAlmostEqual(self.profile.GetPar("Eta0").GetValue(), eta0_original + 0.1)
 
     def test_xml_input(self):
-        assert True
+        """Ensure XMLInput restores parameters previously serialized with xml()."""
+        xml_state = self.profile.xml()
+        eta0_original = self.profile.GetPar("Eta0").GetValue()
+
+        self.profile.GetPar("Eta0").SetValue(eta0_original + 0.3)
+        self.assertNotAlmostEqual(self.profile.GetPar("Eta0").GetValue(), eta0_original)
+
+        RefinableObj.XMLInput(self.profile, xml_state)
+        self.assertAlmostEqual(self.profile.GetPar("Eta0").GetValue(), eta0_original)
 
     def test_xml_output(self):
-        assert True
+        """Ensure XMLOutput emits parameter tags and the expected root element."""
+        xml_state = self.profile.xml()
+
+        self.assertIn("<ReflectionProfile", xml_state)
+        for par_name in ("U", "V", "W", "Eta0"):
+            self.assertIn(f'Name="{par_name}"', xml_state)
+
+        import io
+
+        buf = io.StringIO()
+        RefinableObj.XMLOutput(self.profile, buf, 0)
+        xml_from_stream = buf.getvalue()
+        self.assertTrue(xml_from_stream.startswith("<ReflectionProfile"))
 
 
 if __name__ == "__main__":

--- a/tests/test_reflectionprofile.py
+++ b/tests/test_reflectionprofile.py
@@ -38,7 +38,8 @@ class TestReflectionProfile(unittest.TestCase):
         self.profile = self.ppd.GetProfile()
 
     def test_get_computed_profile(self):
-        """Sample a profile slice and verify broadening lowers the peak height."""
+        """Sample a profile slice and verify broadening lowers the peak
+        height."""
         x = self.pp.GetPowderPatternX()
         hkl = (1, 0, 0)
         window = x[100:200]
@@ -58,7 +59,9 @@ class TestReflectionProfile(unittest.TestCase):
 
     def test_get_profile_width(self):
         """Ensure full-width increases when W increases."""
-        xcenter = float(self.pp.GetPowderPatternX()[len(self.pp.GetPowderPatternX()) // 4])
+        xcenter = float(
+            self.pp.GetPowderPatternX()[len(self.pp.GetPowderPatternX()) // 4]
+        )
         width_default = self.profile.GetFullProfileWidth(0.5, xcenter, 1, 0, 0)
         self.assertGreater(width_default, 0)
 
@@ -67,7 +70,8 @@ class TestReflectionProfile(unittest.TestCase):
         self.assertGreater(width_broader, width_default)
 
     def test_create_copy(self):
-        """Ensure copy returns an independent profile with identical initial params."""
+        """Ensure copy returns an independent profile with identical
+        initial params."""
         copy = self.profile.CreateCopy()
 
         self.assertIsNot(copy, self.profile)
@@ -80,22 +84,32 @@ class TestReflectionProfile(unittest.TestCase):
         self.profile.GetPar("Eta0").SetValue(eta0_original + 0.1)
         copy.GetPar("Eta0").SetValue(eta0_copy + 0.2)
 
-        self.assertAlmostEqual(copy.GetPar("Eta0").GetValue(), eta0_original + 0.2)
-        self.assertAlmostEqual(self.profile.GetPar("Eta0").GetValue(), eta0_original + 0.1)
+        self.assertAlmostEqual(
+            copy.GetPar("Eta0").GetValue(), eta0_original + 0.2
+        )
+        self.assertAlmostEqual(
+            self.profile.GetPar("Eta0").GetValue(), eta0_original + 0.1
+        )
 
     def test_xml_input(self):
-        """Ensure XMLInput restores parameters previously serialized with xml()."""
+        """Ensure XMLInput restores parameters previously serialized
+        with xml()."""
         xml_state = self.profile.xml()
         eta0_original = self.profile.GetPar("Eta0").GetValue()
 
         self.profile.GetPar("Eta0").SetValue(eta0_original + 0.3)
-        self.assertNotAlmostEqual(self.profile.GetPar("Eta0").GetValue(), eta0_original)
+        self.assertNotAlmostEqual(
+            self.profile.GetPar("Eta0").GetValue(), eta0_original
+        )
 
         RefinableObj.XMLInput(self.profile, xml_state)
-        self.assertAlmostEqual(self.profile.GetPar("Eta0").GetValue(), eta0_original)
+        self.assertAlmostEqual(
+            self.profile.GetPar("Eta0").GetValue(), eta0_original
+        )
 
     def test_xml_output(self):
-        """Ensure XMLOutput emits parameter tags and the expected root element."""
+        """Ensure XMLOutput emits parameter tags and the expected root
+        element."""
         xml_state = self.profile.xml()
 
         self.assertIn("<ReflectionProfile", xml_state)

--- a/tests/test_reflectionprofile.py
+++ b/tests/test_reflectionprofile.py
@@ -1,11 +1,4 @@
-"""Unit tests for pyobjcryst.reflectionprofile bindings.
-
-TODO:
-- ReflectionProfile.GetProfile
-- ReflectionProfile.GetFullProfileWidth
-- ReflectionProfile.XMLOutput / XMLInput
-- ReflectionProfile.CreateCopy
-"""
+"""Unit tests for pyobjcryst.reflectionprofile bindings."""
 
 import unittest
 


### PR DESCRIPTION
Summary of changes:
* allow to build the library via `pip install .` outside of a conda env using `sysconfig` to find the location of the shared libs. 
* added python bindings for the `ReflectionProfile` public methods: 

  ```
    GetProfile, GetFullProfileWidth, XMLOutput, XMLInput
   ```

Tested on Ubuntu 24.04 and Windows 11.