### PR TITLE
Expose `GetPowderPatternObsSigma` and `SetPowderPatternObsSigma`

### DIFF
--- a/news/main.rst
+++ b/news/main.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Expose PowderPattern.GetPowderPatternObsSigma and PowderPattern.SetPowderPatternObsSigma from objcryst

--- a/news/main.rst
+++ b/news/main.rst
@@ -1,3 +1,23 @@
 **Added:**
 
 * Expose PowderPattern.GetPowderPatternObsSigma and PowderPattern.SetPowderPatternObsSigma from objcryst
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,5 +1,5 @@
 numpy
-libobjcryst
+libobjcryst>=2026.1
 libboost-devel
 libboost-python
 packaging # for matplotlib version parsing in powderpattern.py

--- a/src/extensions/powderpattern_ext.cpp
+++ b/src/extensions/powderpattern_ext.cpp
@@ -141,6 +141,13 @@ void setpowderpatternobs (PowderPattern& pp, bp::object x)
     pp.SetPowderPatternObs(cvx);
 }
 
+void setpowderpatternobssigma (PowderPattern& pp, bp::object x)
+{
+    CrystVector_REAL cvx;
+    assignCrystVector(cvx, x);
+    pp.SetPowderPatternObsSigma(cvx);
+}
+
 
 // Allow override (since we can't benefit from override in RefinableObjWrap)
 class PowderPatternWrap : public PowderPattern, public wrapper<PowderPattern>
@@ -230,6 +237,9 @@ void wrap_powderpattern()
         .def("GetPowderPatternObs",
                 &PowderPattern::GetPowderPatternObs,
                 return_value_policy<copy_const_reference>())
+        .def("GetPowderPatternObsSigma",
+                &PowderPattern::GetPowderPatternObsSigma,
+                return_value_policy<copy_const_reference>())
         .def("GetPowderPatternX",
                 &PowderPattern::GetPowderPatternX,
                 return_value_policy<copy_const_reference>())
@@ -287,6 +297,9 @@ void wrap_powderpattern()
         .def("SetPowderPatternObs",
                 &setpowderpatternobs,
                 bp::arg("obs"))
+        .def("SetPowderPatternObsSigma",
+                &setpowderpatternobssigma,
+                bp::arg("sigma"))
         .def("FitScaleFactorForR",
                 &PowderPattern::FitScaleFactorForR)
         .def("FitScaleFactorForIntegratedR",

--- a/tests/test_powderpattern.py
+++ b/tests/test_powderpattern.py
@@ -101,6 +101,17 @@ class TestPowderPattern(unittest.TestCase):
         self.assertTrue(np.array_equal(obs[::-1], pp.GetPowderPatternObs()))
         return
 
+    def test_SetPowderPatternObsSigma(self):
+        pp = self.pp
+        obs = np.array([1.0, 3.0, 7.0])
+        sig = np.array([1.0, 2.0, 3.0])
+        self.assertRaises(ObjCrystException, pp.SetPowderPatternObsSigma, sig)
+        pp.SetPowderPatternPar(0, 0.5, 3)
+        pp.SetPowderPatternObs(obs)
+        pp.SetPowderPatternObsSigma(sig)
+        self.assertTrue(np.array_equal(sig, pp.GetPowderPatternObsSigma()))
+        return
+
     def test_SetPowderPatternPar(self):
         pp = self.pp
         pp.SetPowderPatternPar(0, 0.25, 5)


### PR DESCRIPTION
Expose existing `PowderPattern::GetPowderPatternObsSigma` and expose/implement `PowderPattern::SetPowderPatternObsSigma`. The latter is implemented in objcryst in https://github.com/vincefn/objcryst/pull/68.