### PR TITLE
fix: lower default minimum unit cell length in quick_index to 2.5 Å

### DIFF
--- a/news/90.rst
+++ b/news/90.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* ``quick_index()`` now accepts a ``length_min`` parameter (default: 2.5 Å)
+  to control the minimum unit cell length explored during indexing.
+
+**Changed:**
+
+* ``quick_index()`` default minimum unit cell length lowered from 3 Å to 2.5 Å,
+  allowing correct indexing of compact structures such as α-Fe, B, or ZRNCl
+  (`issue #47 <https://github.com/diffpy/pyobjcryst/issues/47>`_).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/pyobjcryst/indexing.py
+++ b/src/pyobjcryst/indexing.py
@@ -54,6 +54,7 @@ def quick_index(
     try_centered_lattice=True,
     continue_on_sol=False,
     max_nb_spurious=0,
+    length_min=2.5,
     verbose=True,
 ):
     if len(pl) > nb_refl:
@@ -70,7 +71,7 @@ def quick_index(
         )
         print("Starting indexing using %2u peaks" % nb)
     ex = CellExplorer(pl, CrystalSystem.CUBIC, 0)
-    ex.SetLengthMinMax(3, 25)
+    ex.SetLengthMinMax(length_min, 25)
     ex.SetAngleMinMax(deg2rad(90), deg2rad(140))
     ex.SetD2Error(0)
     stop_score = 50
@@ -139,7 +140,7 @@ def quick_index(
                 lengthmax = 3 * maxv ** (1 / 3.0)
                 if lengthmax < 25:
                     lengthmax = 25
-                ex.SetLengthMinMax(3, lengthmax)
+                ex.SetLengthMinMax(length_min, lengthmax)
                 ex.SetCrystalSystem(csys)
                 ex.SetCrystalCentering(cent)
                 if verbose:


### PR DESCRIPTION
### What problem does this PR address?

Closes #47.

`quick_index()` had the minimum unit cell length hardcoded to 3 Å, which prevents correct indexing of compact structures (e.g. α-Fe *a*≈2.87 Å, B *a*≈2.9 Å, ZRNCl). According to the COD there are ~430 orthorhombic structures with *a* between 2.5–3 Å.

The same default has been fixed in the upstream ObjCryst C++ library (vincefn/objcryst#80, `mLengthMin` 4 Å → 2.5 Å).

### What should the reviewer(s) do?

Review the change and merge.

- [x] This PR introduces a public-facing change (API: new `length_min` parameter in `quick_index()`).