### PR TITLE
Fix displ_transl toggle in quick_fit_profile

### DIFF
--- a/news/83.rst
+++ b/news/83.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* None.
+
+**Changed:**
+
+* None.
+
+**Deprecated:**
+
+* None.
+
+**Removed:**
+
+* None.
+
+**Fixed:**
+
+* `quick_fit_profile(displ_transl=True)` now correctly enables refinement of `2ThetaDispl` and `2ThetaTransp` by unfixing both parameters.
+
+**Security:**
+
+* None.

--- a/src/pyobjcryst/powderpattern.py
+++ b/src/pyobjcryst/powderpattern.py
@@ -425,8 +425,8 @@ class PowderPattern(PowderPattern_objcryst):
         if zero:
             lsq.SetParIsFixed("Zero", False)
         if displ_transl:
-            lsq.SetParIsFixed("2ThetaDispl", True)
-            lsq.SetParIsFixed("2ThetaTransp", True)
+            lsq.SetParIsFixed("2ThetaDispl", False)
+            lsq.SetParIsFixed("2ThetaTransp", False)
         if lsqr.GetNbParNotFixed():
             lsq.SafeRefine(nbCycle=10, useLevenbergMarquardt=True, silent=True)
             pdiff.ExtractLeBail(10)

--- a/tests/test_powderpattern.py
+++ b/tests/test_powderpattern.py
@@ -15,6 +15,7 @@
 """Unit tests for pyobjcryst.powderpattern (with indexing &"""
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -184,6 +185,44 @@ class TestPowderPattern(unittest.TestCase):
         p.SetPowderPatternObs(obs)
         p.SetMaxSinThetaOvLambda(0.3)
         p.quick_fit_profile(auto_background=True, verbose=False, plot=False)
+
+    def test_quick_fit_profile_displ_transl_unfixes_refinement_parameters(
+        self,
+    ):
+        fake_powder_pattern = MagicMock()
+        fake_diffraction = MagicMock()
+        fake_lsqr = MagicMock()
+        fake_lsqr.GetNbParNotFixed.return_value = 0
+        fake_lsq = MagicMock()
+        fake_lsq.GetCompiledRefinedObj.return_value = fake_lsqr
+
+        with patch("pyobjcryst.powderpattern.LSQ", return_value=fake_lsq):
+            PowderPattern.quick_fit_profile(
+                fake_powder_pattern,
+                pdiff=fake_diffraction,
+                auto_background=False,
+                init_profile=False,
+                plot=False,
+                zero=False,
+                constant_width=False,
+                width=False,
+                eta=False,
+                cell=False,
+                asym=False,
+                backgd=False,
+                displ_transl=True,
+                verbose=False,
+            )
+
+        displ_transl_calls = [
+            call.args
+            for call in fake_lsq.SetParIsFixed.call_args_list
+            if call.args[0] in ("2ThetaDispl", "2ThetaTransp")
+        ]
+        self.assertEqual(
+            displ_transl_calls,
+            [("2ThetaDispl", False), ("2ThetaTransp", False)],
+        )
 
     def test_peaklist_index(self):
         c = self.loadcifdata("paracetamol.cif")


### PR DESCRIPTION
### What problem does this PR address?

Fixes #83. `quick_fit_profile(displ_transl=True)` incorrectly fixed `2ThetaDispl` and `2ThetaTransp`, so they were not refined.

This PR changes those flags to `False` so both parameters are actually refined when `displ_transl=True`. It also adds:

- a regression test in `tests/test_powderpattern.py`
- a news item in `news/83.rst`

### What should the reviewer(s) do?

Check that the toggle logic in `quick_fit_profile` now matches the other refinement toggles and that the new test captures the regression.