### PR TITLE
feat: expose Radiation.GetLinearPolarRate / SetLinearPolarRate and clock accessors

### DIFF
--- a/news/93.rst
+++ b/news/93.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* Exposed ``Radiation.GetLinearPolarRate()``, ``Radiation.SetLinearPolarRate()``,
+  ``Radiation.GetClockWavelength()``, and ``Radiation.GetClockRadiation()`` via
+  Python bindings. Closes `#38 <https://github.com/diffpy/pyobjcryst/issues/38>`_.
+  ``Radiation.GetClockLinearPolarRate()`` is also bound and will be available once
+  `diffpy/libobjcryst` picks up `vincefn/objcryst PR #79
+  <https://github.com/vincefn/objcryst/pull/79>`_, which adds the dedicated
+  polarisation clock and fixes the polarisation-correction recalculation trigger.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/extensions/radiation_ext.cpp
+++ b/src/extensions/radiation_ext.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include <ObjCryst/ObjCryst/ScatteringData.h>
+#include <ObjCryst/version.h>
 
 namespace bp = boost::python;
 using namespace boost::python;
@@ -51,5 +52,15 @@ void wrap_radiation()
         (bp::arg("XRayTubeElementName"), bp::arg("alpha2Alpha2ratio")=0.5))
         .def("GetXRayTubeDeltaLambda", & Radiation::GetXRayTubeDeltaLambda)
         .def("GetXRayTubeAlpha2Alpha1Ratio", & Radiation::GetXRayTubeAlpha2Alpha1Ratio)
+        .def("GetLinearPolarRate", &Radiation::GetLinearPolarRate)
+        .def("SetLinearPolarRate", &Radiation::SetLinearPolarRate)
+        .def("GetClockWavelength", &Radiation::GetClockWavelength,
+             return_value_policy<copy_const_reference>())
+        .def("GetClockRadiation", &Radiation::GetClockRadiation,
+             return_value_policy<copy_const_reference>())
+#if LIBOBJCRYST_VERSION >= 2026002000000LL
+        .def("GetClockLinearPolarRate", &Radiation::GetClockLinearPolarRate,
+             return_value_policy<copy_const_reference>())
+#endif
         ;
 }

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -44,6 +44,17 @@ class TestRadiation(unittest.TestCase):
         )
         return
 
+    def testLinearPolarRate(self):
+        """Test getting and setting linear polarisation rate."""
+        r = Radiation()
+        # Default for X-ray should be 0
+        self.assertAlmostEqual(r.GetLinearPolarRate(), 0.0)
+        r.SetLinearPolarRate(0.95)
+        self.assertAlmostEqual(r.GetLinearPolarRate(), 0.95)
+        r.SetLinearPolarRate(0.0)
+        self.assertAlmostEqual(r.GetLinearPolarRate(), 0.0)
+        return
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What problem does this PR address?

Issue #38 — the linear polarisation rate was not accessible from Python.

### What was done

- Bound `Radiation.GetLinearPolarRate()` and `Radiation.SetLinearPolarRate()` (already in current libobjcryst).
- Bound `Radiation.GetClockWavelength()` and `Radiation.GetClockRadiation()` (were missing).
- Bound `Radiation.GetClockLinearPolarRate()` behind a `LIBOBJCRYST_VERSION >= 2026002000000LL` guard — this requires [vincefn/objcryst PR #79](https://github.com/vincefn/objcryst/pull/79) to be picked up by a future libobjcryst release.
- Added `tests/test_radiation.py::testLinearPolarRate`.

### Dependency note

The polarisation-correction recalculation fix (so that changing the linear polar rate actually triggers a recalc) depends on [vincefn/objcryst PR #79](https://github.com/vincefn/objcryst/pull/79), which is merged upstream but not yet in a libobjcryst release. The new bindings work with the current libobjcryst; the full fix will be active once libobjcryst is updated.

Closes #38