### PR TITLE
fix: fix spelling and changelog, pre-commit auto-fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,8 +83,8 @@ repos:
         additional_dependencies:
           - "prettier@^3.2.4"
   # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/s-weigand/docformatter
-    rev: 5757c5190d95e5449f102ace83df92e7d3b06c6c
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,63 +17,63 @@ Release notes
 
 
 Version 2024.2.2
-----------------
+=====
 
-**Fixes:**
+**Fixed:**
 
 * Correct powder pattern plotting with a non-empty name
 
 Version 2024.2.1
-----------------
+=====
 
-**Changes:**
+**Changed:**
 
 * PowderPattern:
   * Fix re-using a matplotlib figure when plotting
   * Add ``figure`` property
 
 Version 2024.2
---------------
+=====
 
-**Changes:**
+**Changed:**
 
 * **DiffractionDataSingleCrystal**: add ``SetHklIobs``, ``SetIobs``, ``SetSigma``, ``GetSigma``, ``GetChi2``, ``FitScaleFactorForRw`` and ``FitScaleFactorForR`` (`issue #42 <https://github.com/diffpy/pyobjcryst/issues/42>`_)
 * Add a single crystal data notebook example
 * Online documentation notebooks now include the plots `<https://pyobjcryst.readthedocs.io/en/latest/examples>`_
 
-**Fixes:**
+**Fixed:**
 
 * From libobjcryst: update the ScatteringComponentList when a Scatterer is removed from a Crystal (`issue #41 <https://github.com/diffpy/pyobjcryst/issues/41>`_)
 
 Version 2024.1
---------------
+=====
 
-**Changes:**
+**Changed:**
 
 * Add python access to MolZAtom, for ``Molecule.AsZMatrix()``
 
 Version 2.2.6
---------------
+=====
 
-**Changes:**
+**Changed:**
 
 * Support for Windows and Python>=3.8
 * Added a zoom limit for 3D crystal views
 
-**Fixes:**
+**Fixed:**
 
 * Correct error preventing pyobjcryst import for Windows and Python>=3.8 (`issue #33 <https://github.com/diffpy/pyobjcryst/issues/33>`_)
 * Fix for matplotlib >=3.7.0 when removing hkl labels
 
 Version 2.2.5
---------------
+=====
 
-**Changes:**
+**Changed:**
 
 * Raise an exception if ``alpha``, ``beta`` or ``gamma`` are not within ``]0;pi[`` when changing lattice angles
 * Add ``UnitCell.ChangeSpaceGroup()``
 
-**Fixes:**
+**Fixed:**
 
 * Avoid duplication of plots when using ipympl (aka ``%matplotlib widget``)
 * Correct powder pattern tests to avoid warnings
@@ -83,9 +83,9 @@ Version 2.2.5
 * ``loadCrystal`` – use ``create_crystal_from_cif()`` instead
 
 Version 2.2.4
---------------
+=====
 
-**Changes:**
+**Changed:**
 
 * The list of HKL reflections will now be automatically re-generated for a ``PowderPatternDiffraction`` when the Crystal's spacegroup changes, or the lattice parameters are modified by more than 0.5%
 
@@ -94,7 +94,7 @@ Version 2.2.4
 * Fixed the powder pattern indexing test
 
 Version 2.2.3
---------------
+=====
 
 **Added:**
 
@@ -104,9 +104,9 @@ Version 2.2.3
 * Add ``gDiffractionDataSingleCrystalRegistry`` to globals
 
 Version 2.2.2
---------------
+=====
 
-**Changes:**
+**Changed:**
 
 * Add correct wrapping for C++-instantiated objects available through global registries, e.g. when loading an XML file. The objects are decorated with the python functions when accessed through the global registries ``GetObj()``
 * Moved global object registries to ``pyobjcryst.globals``
@@ -118,7 +118,7 @@ Version 2.2.2
 * Fix powder pattern plot issues (NaN and update of hkl text with recent matplotlib versions)
 
 Version 2.2.1 -- 2021-11-28
-----------------------------
+=====
 
 * Add quantitative phase analysis with ``PowderPattern.qpa()``, including an example notebook using the QPA Round-Robin data
 * Correct import of ``urllib.request.urllopen()`` when loading CIF or z-matrix files from HTTP URLs
@@ -128,14 +128,14 @@ Version 2.2.1 -- 2021-11-28
 * Fix issue when using ``Crystal.XMLInput()`` for a non-empty structure. Existing scattering power will be re-used when possible, and otherwise not deleted anymore (which could lead to crashes)
 
 Version 2.2.0 -- 2021-06-08
-----------------------------
+=====
 
 * Add access to ``Radiation`` class & functions to change RadiationType, wavelength in ``PowderPattern`` and ``ScatteringData`` (and hence ``DiffractionDataSingleCrystal``) classes
 * Fix the custodian_ward when creating a ``PowderPatternDiffraction``: ``PowderPatternDiffraction`` must persist while ``PowderPattern`` exists, and Crystal must persist while ``PowderPatternDiffraction`` exists
 * Add 3D Crystal viewer ``pyobjcryst.crystal.Crystal.widget_3d``
 
 Version 2.1.0 -- 2019-03-11
-----------------------------
+=====
 
 **Added:**
 

--- a/news/fix-spelling-and-changelog.rst
+++ b/news/fix-spelling-and-changelog.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Exposed the correctly spelled `ORTHORHOMBIC` while preserving `ORTHOROMBIC` as temporary backend compatible alias
+
+**Security:**
+
+* <news item>

--- a/news/fix-spelling-and-changelog.rst
+++ b/news/fix-spelling-and-changelog.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Exposed the correctly spelled `ORTHORHOMBIC` while preserving `ORTHOROMBIC` as temporary backend compatible alias
+* Exposed the correctly spelled `ORTHORHOMBIC` while preserving `ORTHOROMBIC` as temporary backend compatible alias.
 
 **Security:**
 

--- a/news/fix-spelling-and-changelog.rst
+++ b/news/fix-spelling-and-changelog.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Exposed the correctly spelled `ORTHORHOMBIC` while preserving `ORTHOROMBIC` as temporary backend compatible alias.
+* Exposed the correctly spelled `ORTHORHOMBIC` while preserving `ORTHOROMBIC` as temporary backend compatible alias
 
 **Security:**
 

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,5 +1,5 @@
 numpy
-libobjcryst>=2026.1
+libobjcryst>=2026.2.0
 libboost-devel
 libboost-python
 packaging # for matplotlib version parsing in powderpattern.py

--- a/src/extensions/indexing_ext.cpp
+++ b/src/extensions/indexing_ext.cpp
@@ -70,7 +70,7 @@ std::string __str__RecUnitCell(RecUnitCell& ruc)
     {
       case TRICLINIC:sys="TRICLINIC"; break;
       case MONOCLINIC:sys="MONOCLINIC"; break;
-      case ORTHOROMBIC:sys="ORTHOROMBIC"; break;
+      case ORTHORHOMBIC:sys="ORTHORHOMBIC"; break;
       case HEXAGONAL:sys="HEXAGONAL"; break;
       case RHOMBOEDRAL:sys="RHOMBOEDRAL"; break;
       case TETRAGONAL:sys="TETRAGONAL"; break;
@@ -299,6 +299,7 @@ void wrap_indexing()
         .value("TRICLINIC", TRICLINIC)
         .value("MONOCLINIC", MONOCLINIC)
         .value("ORTHOROMBIC", ORTHOROMBIC)
+        .value("ORTHORHOMBIC", ORTHORHOMBIC)
         .value("HEXAGONAL", HEXAGONAL)
         .value("RHOMBOEDRAL", RHOMBOEDRAL)
         .value("TETRAGONAL", TETRAGONAL)

--- a/src/pyobjcryst/crystal.py
+++ b/src/pyobjcryst/crystal.py
@@ -277,7 +277,6 @@ class Crystal(Crystal_orig):
             independent atoms, no symmetry or translation is applied
         :return : the list of atoms and bonds to be displayed for 3dmol
         """
-
         spg = self.GetSpaceGroup()
         vv = []
         idx = 0

--- a/src/pyobjcryst/diffractiondatasinglecrystal.py
+++ b/src/pyobjcryst/diffractiondatasinglecrystal.py
@@ -36,9 +36,9 @@ from pyobjcryst._pyobjcryst import (
 
 
 def create_singlecrystaldata_from_cif(file, crystal):
-    """
-    Create a DiffractionDataSingleCrystal object from a CIF file. Note that
-    this will use the last created Crystal as a reference structure.
+    """Create a DiffractionDataSingleCrystal object from a CIF file.
+
+    Note that this will use the last created Crystal as a reference structure.
     Example using the COD to load both crystal and data:
         c=create_crystal_from_cif('http://www.crystallography.net/cod/2201530.cif')
         d=create_singlecrystaldata_from_cif('http://www.crystallography.net/cod/2201530.hkl', c)

--- a/src/pyobjcryst/globaloptim.py
+++ b/src/pyobjcryst/globaloptim.py
@@ -16,6 +16,7 @@ See the online ObjCryst++ documentation (https://objcryst.readthedocs.io).
 Changes from ObjCryst::MonteCarloObj::
         In development !
 """
+
 __all__ = ["MonteCarlo", "AnnealingSchedule", "GlobalOptimType"]
 
 import warnings

--- a/src/pyobjcryst/indexing.py
+++ b/src/pyobjcryst/indexing.py
@@ -84,7 +84,7 @@ def quick_index(
             CrystalSystem.TETRAGONAL,
             CrystalSystem.RHOMBOEDRAL,
             CrystalSystem.HEXAGONAL,
-            CrystalSystem.ORTHOROMBIC,
+            CrystalSystem.ORTHORHOMBIC,
             CrystalSystem.MONOCLINIC,
         ]:
             if csys == CrystalSystem.CUBIC:
@@ -99,7 +99,7 @@ def quick_index(
                 vcen = [CrystalCentering.LATTICE_P]
             elif csys == CrystalSystem.HEXAGONAL:
                 vcen = [CrystalCentering.LATTICE_P]
-            elif csys == CrystalSystem.ORTHOROMBIC:
+            elif csys == CrystalSystem.ORTHORHOMBIC:
                 vcen = [
                     CrystalCentering.LATTICE_P,
                     CrystalCentering.LATTICE_A,

--- a/src/pyobjcryst/molecule.py
+++ b/src/pyobjcryst/molecule.py
@@ -126,8 +126,9 @@ from .zscatterer import ZScatterer
 
 
 def ImportFenskeHallZMatrix(cryst, src, named=False):
-    """Create a Molecule from a Fenske-Hall z-matrix. This is cleaner
-    than importing the Z-matrix into a ZScatterer object and then using
+    """Create a Molecule from a Fenske-Hall z-matrix.
+
+    This is cleaner than importing the Z-matrix into a ZScatterer object and then using
     ZScatterer2Molecule, as it takes care of keeping only the created
     Molecule inside the Crystal.
 

--- a/src/pyobjcryst/powderpattern.py
+++ b/src/pyobjcryst/powderpattern.py
@@ -338,11 +338,11 @@ class PowderPattern(PowderPattern_objcryst):
 
     @property
     def figure(self):
-        """
-        return: the figure used for plotting, or None. Note that
-            if you want to display it in a notebook using ipympl (aka
-            'matplotlib widget'), you should 'figure.canvas' to display
-            also the toolbar (zoom, etc...).
+        """Return: the figure used for plotting, or None.
+
+        Note that if you want to display it in a notebook using ipympl
+        (aka 'matplotlib widget'), you should 'figure.canvas' to display
+        also the toolbar (zoom, etc...).
         """
         return self._plot_fig
 

--- a/src/pyobjcryst/utils.py
+++ b/src/pyobjcryst/utils.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Utilities for crystals."""
 
-
 # FIXME: check if this function does any meaningful job.
 
 
@@ -95,7 +94,6 @@ def putAtomsInMolecule(crystal, alist=None, name=None):
 def _xyztostring(crystal):
     """Helper function to write xyz coordinates of a crystal to a
     string."""
-
     nsc = 0
     out = ""
     scl = crystal.GetScatteringComponentList()

--- a/tests/pyobjcryst_test_mem.py
+++ b/tests/pyobjcryst_test_mem.py
@@ -12,8 +12,9 @@
 # See LICENSE_DANSE.txt for license information.
 #
 ##############################################################################
-"""Small tests for pyobjcryst. Not run by pytest, for memory leak
-checks.
+"""Small tests for pyobjcryst.
+
+Not run by pytest, for memory leak checks.
 
 To check for memory leaks, run valgrind --tool=memcheck --leak-
 check=full python ./pyobjcrysttest.py

--- a/tests/test_crystal.py
+++ b/tests/test_crystal.py
@@ -141,7 +141,6 @@ class TestCrystal(unittest.TestCase):
 
     def testEmbedding(self):
         """Test integrity of mutually-embedded objects."""
-
         c = makeCrystal(*makeScatterer())
 
         class Level1(object):

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -56,7 +56,7 @@ class TestIndexing(unittest.TestCase):
             1 / 1.537,
             1 / 47.326,
             20,
-            CrystalSystem.ORTHOROMBIC,
+            CrystalSystem.ORTHORHOMBIC,
             CrystalCentering.LATTICE_F,
             1.2,
         )
@@ -65,7 +65,7 @@ class TestIndexing(unittest.TestCase):
             1 / 1.537,
             1 / 47.326,
             20,
-            CrystalSystem.ORTHOROMBIC,
+            CrystalSystem.ORTHORHOMBIC,
             CrystalCentering.LATTICE_I,
             0.3,
         )

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -165,7 +165,6 @@ class TestMolecule(unittest.TestCase):
 
     def testBonds(self):
         """Test the Bond methods."""
-
         a1 = self.m.GetAtom(0)
         a2 = self.m.GetAtom(1)
         a3 = self.m.GetAtom(2)
@@ -746,7 +745,6 @@ class TestStretchModeBondLength(unittest.TestCase):
 
     def testStretchModeBondLength(self):
         """Test the StretchModeBondLength class."""
-
         # Measure the distance
         ac = self.m[0]
         # The 0, 0, z atom
@@ -795,7 +793,6 @@ class TestStretchModeBondAngle(unittest.TestCase):
 
     def testStretchModeBondAngle(self):
         """Test the StretchModeBondLength class."""
-
         a1 = self.m[1]
         ac = self.m[0]
         a2 = self.m[2]
@@ -839,7 +836,6 @@ class TestStretchModeTorsion(unittest.TestCase):
 
     def testStretchModeTorsion(self):
         """Test the StretchModeBondLength class."""
-
         a1 = self.m[1]
         ac0 = self.m[3]
         ac1 = self.m[0]

--- a/tests/test_spacegroup.py
+++ b/tests/test_spacegroup.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for pyobjcryst.spacegroup."""
 
-
 import unittest
 
 from pyobjcryst.spacegroup import SpaceGroup


### PR DESCRIPTION
Closes #55, #82 
In this PR, I fixed spelling and CHANGLOG formatting issues. For `index_ext.cpp`, I left one wrap indexing `ORTHOROMBIC` for backend-compatible alias in case someone who uses misspelling one. But for next main release, we should remove this.